### PR TITLE
Enhance argument passing for syscall

### DIFF
--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -109,7 +109,7 @@ int get_code_length(ir_instr_t *ii)
     case OP_geq:
         return 12;
     case OP_syscall:
-        return 20;
+        return 32;
     case OP_func_exit:
         return 16;
     case OP_exit:
@@ -512,6 +512,9 @@ void code_generate()
             emit(__mov_r(__AL, __r0, __r1));
             emit(__mov_r(__AL, __r1, __r2));
             emit(__mov_r(__AL, __r2, __r3));
+            emit(__mov_r(__AL, __r3, __r4));
+            emit(__mov_r(__AL, __r4, __r5));
+            emit(__mov_r(__AL, __r5, __r6));
             emit(__svc());
             DUMP_IR("    syscall");
             break;

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -102,7 +102,7 @@ int get_code_length(ir_instr_t *ii)
         return (blk->next_local > 0) ? 4 : 0;
     }
     case OP_syscall:
-        return 20;
+        return 32;
     case OP_eq:
     case OP_neq:
     case OP_lt:
@@ -536,6 +536,9 @@ void code_generate()
             emit(__addi(__a0, __a1, 0));
             emit(__addi(__a1, __a2, 0));
             emit(__addi(__a2, __a3, 0));
+            emit(__addi(__a3, __a4, 0));
+            emit(__addi(__a4, __a5, 0));
+            emit(__addi(__a5, __a6, 0));
             emit(__ecall());
             DUMP_IR("    syscall");
             break;


### PR DESCRIPTION
In the previous version, only three arguments were passed for system calls. Therefore, I expanded it to support the passing of up to six arguments for system calls like mmap.