### PR TITLE
Avoid variable conflicts while expanding macros

### DIFF
--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -525,6 +525,5 @@ void code_generate()
         default:
             error("Unsupported IR opcode");
         }
-        DUMP_IR("\n");
     }
 }

--- a/src/defs.h
+++ b/src/defs.h
@@ -29,17 +29,18 @@
 #define ELF_START 0x10000
 #define PTR_SIZE 4
 
-#define DUMP_IR(...)                            \
-    do {                                        \
-        int i;                                  \
-        if (!dump_ir)                           \
-            break;                              \
-                                                \
-        printf("%#010x     ", code_start + pc); \
-        for (i = 0; i < _c_block_level; i++)    \
-            printf("    ");                     \
-                                                \
-        printf(__VA_ARGS__);                    \
+#define DUMP_IR(...)                                                 \
+    do {                                                             \
+        int dump_ir_i;                                               \
+        if (!dump_ir)                                                \
+            break;                                                   \
+                                                                     \
+        printf("%#010x     ", code_start + pc);                      \
+        for (dump_ir_i = 0; dump_ir_i < _c_block_level; dump_ir_i++) \
+            printf("    ");                                          \
+                                                                     \
+        printf(__VA_ARGS__);                                         \
+        printf("\n");                                                \
     } while (0)
 
 /* builtin types */

--- a/src/defs.h
+++ b/src/defs.h
@@ -29,18 +29,19 @@
 #define ELF_START 0x10000
 #define PTR_SIZE 4
 
-#define DUMP_IR(...)                                                 \
-    do {                                                             \
-        int dump_ir_i;                                               \
-        if (!dump_ir)                                                \
-            break;                                                   \
-                                                                     \
-        printf("%#010x     ", code_start + pc);                      \
-        for (dump_ir_i = 0; dump_ir_i < _c_block_level; dump_ir_i++) \
-            printf("    ");                                          \
-                                                                     \
-        printf(__VA_ARGS__);                                         \
-        printf("\n");                                                \
+#define DUMP_IR(...)                                              \
+    do {                                                          \
+        int __dump_ir_iter;                                       \
+        if (!dump_ir)                                             \
+            break;                                                \
+                                                                  \
+        printf("%#010x     ", code_start + pc);                   \
+        for (__dump_ir_iter = 0; __dump_ir_iter < _c_block_level; \
+             __dump_ir_iter++)                                    \
+            printf("    ");                                       \
+                                                                  \
+        printf(__VA_ARGS__);                                      \
+        printf("\n");                                             \
     } while (0)
 
 /* builtin types */

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -548,6 +548,5 @@ void code_generate()
         default:
             error("Unsupported IR op");
         }
-        DUMP_IR("\n");
     }
 }


### PR DESCRIPTION
Rename the counter `i` in `DUMP_IR` macro to prevent the conflict after macro expansion.

Fix the dumped IR format.