### PR TITLE
Improve architecture detection and configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ STAGE1 := shecc-stage1.elf
 STAGE2 := shecc-stage2.elf
 
 OUT ?= out
-ARCH := arm
+ARCH ?= arm
 SRCDIR := $(shell find src -type d)
 LIBDIR := $(shell find lib -type d)
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ STAGE1 := shecc-stage1.elf
 STAGE2 := shecc-stage2.elf
 
 OUT ?= out
+ARCH := arm
 SRCDIR := $(shell find src -type d)
 LIBDIR := $(shell find lib -type d)
 
@@ -24,11 +25,8 @@ TESTBINS := $(TESTS:%.c=$(OUT)/%.elf)
 
 all: config bootstrap
 
-# set ARM by default
-ifeq ($(strip $(ARCH)),riscv)
-ARCH = riscv
-else
-ARCH = arm
+ifeq (,$(filter $(ARCH),arm riscv))
+$(error Support ARM and RISC-V only. Select the target with "ARCH=arm" or "ARCH=riscv")
 endif
 
 ifneq ("$(wildcard $(PWD)/config)","")

--- a/mk/arm.mk
+++ b/mk/arm.mk
@@ -9,8 +9,8 @@ export ARM_EXEC
 
 arm-specific-defs = \
     $(Q)$(PRINTF) \
-" /* target: ARM */\n\
-  \#define ARCH_PREDEFINED \"__arm__\" /* defined by GNU C and RealView */\n\
-  \#define ELF_MACHINE 0x28 /* up to ARMv7/Aarch32 */\n\
-  \#define ELF_FLAGS 0x5000200\n\
-"
+        "/* target: ARM */\n$\
+        \#define ARCH_PREDEFINED \"__arm__\" /* defined by GNU C and RealView */\n$\
+        \#define ELF_MACHINE 0x28 /* up to ARMv7/Aarch32 */\n$\
+        \#define ELF_FLAGS 0x5000200\n$\
+        "

--- a/mk/riscv.mk
+++ b/mk/riscv.mk
@@ -9,8 +9,8 @@ export RISCV_EXEC
 
 riscv-specific-defs = \
     $(Q)$(PRINTF) \
-" /* target: RISCV */\n\
-  \#define ARCH_PREDEFINED \"__riscv\" /* Older versions of the GCC toolchain defined __riscv__ */\n\
-  \#define ELF_MACHINE 0xf3\n\
-  \#define ELF_FLAGS 0\n\
-"
+        "/* target: RISCV */\n$\
+        \#define ARCH_PREDEFINED \"__riscv\" /* Older versions of the GCC toolchain defined __riscv__ */\n$\
+        \#define ELF_MACHINE 0xf3\n$\
+        \#define ELF_FLAGS 0\n$\
+        "


### PR DESCRIPTION
Check the architecture before the building process starting.

Eliminate the leading whitespace in the template string for the auto-generated configure file.