### PR TITLE
Implement #undef preprocessor derictive

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -140,6 +140,7 @@ typedef struct {
     int num_param_defs;
     int params[MAX_PARAMS];
     int num_params;
+    int disabled;
 } macro_t;
 
 /* function definition */
@@ -183,6 +184,7 @@ typedef struct {
 typedef struct {
     char alias[MAX_VAR_LEN];
     char value[MAX_VAR_LEN];
+    int disabled;
 } alias_t;
 
 /* constants for enums */

--- a/src/globals.c
+++ b/src/globals.c
@@ -145,24 +145,57 @@ void add_alias(char *alias, char *value)
     alias_t *al = &ALIASES[aliases_idx++];
     strcpy(al->alias, alias);
     strcpy(al->value, value);
+    al->disabled = 0;
 }
 
 char *find_alias(char alias[])
 {
     int i;
     for (i = 0; i < aliases_idx; i++)
-        if (!strcmp(alias, ALIASES[i].alias))
+        if (!ALIASES[i].disabled && !strcmp(alias, ALIASES[i].alias))
             return ALIASES[i].value;
     return NULL;
+}
+
+int remove_alias(char *alias)
+{
+    int i;
+    for (i = 0; i < aliases_idx; i++) {
+        if (!ALIASES[i].disabled && !strcmp(alias, ALIASES[i].alias)) {
+            ALIASES[i].disabled = 1;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+macro_t *add_macro(char *name)
+{
+    macro_t *ma = &MACROS[macros_idx++];
+    strcpy(ma->name, name);
+    ma->disabled = 0;
+    return ma;
 }
 
 macro_t *find_macro(char *name)
 {
     int i;
     for (i = 0; i < macros_idx; i++)
-        if (!strcmp(name, MACROS[i].name))
+        if (!MACROS[i].disabled && !strcmp(name, MACROS[i].name))
             return &MACROS[i];
     return NULL;
+}
+
+int remove_macro(char *name)
+{
+    int i;
+    for (i = 0; i < macros_idx; i++) {
+        if (!MACROS[i].disabled && !strcmp(name, MACROS[i].name)) {
+            MACROS[i].disabled = 1;
+            return 1;
+        }
+    }
+    return 0;
 }
 
 void error(char *msg);

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -387,6 +387,22 @@ int main()
 }
 EOF
 
+# #define ... #undef
+try_output 0 "1" << EOF
+#define A 1
+void log()
+{
+    printf("%d", A);
+}
+#undef A
+#define A 0
+int main()
+{
+    log();
+    return A;
+}
+EOF
+
 # format
 try_output 0 "2147483647" << EOF
 int main() {


### PR DESCRIPTION
Implements `#undef` preprocessor derictive. 

One concern in current approach is that due to the memory allocations of `alias_t *ALIASES` and `macro_t *MACROS`, the removal operation's time complexity is `O(N)`, this might causes some performance overhead in future development.