### PR TITLE
Support native Arm32 bootstrapping

### DIFF
--- a/mk/arm.mk
+++ b/mk/arm.mk
@@ -1,8 +1,12 @@
-ARM_EXEC = qemu-arm
-ARM_EXEC := $(shell which $(ARM_EXEC))
-ifndef ARM_EXEC
-$(warning "no qemu-arm found. Please check package installation")
-ARM_EXEC = echo WARN: unable to run
+ifeq ($(HOST_ARCH),armv7l) # detect ARMv7-A only and assume Linux-compatible
+    ARM_EXEC :=
+else
+    ARM_EXEC = qemu-arm
+    ARM_EXEC := $(shell which $(ARM_EXEC))
+    ifndef ARM_EXEC
+    $(warning "no qemu-arm found. Please check package installation")
+    ARM_EXEC = echo WARN: unable to run
+    endif
 endif
 
 export ARM_EXEC

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -5,6 +5,8 @@ else
     PRINTF = env printf
 endif
 
+HOST_ARCH = $(shell arch)
+
 # Control the build verbosity
 ifeq ("$(VERBOSE)","1")
     Q :=


### PR DESCRIPTION
When bootstrapping on a native Arm32 host, `qemu-arm` is unnecessary. Therefore, in this configuration, we disregard `ARM_EXEC`.