### PR TITLE
Fix branch-misses on Raspberry Pi 3B

### DIFF
--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -315,7 +315,7 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
         emit(__movt(__AL, __r8, ph2_ir->src1 + 4));
         emit(__add_r(__AL, __sp, __sp, __r8));
         emit(__lw(__AL, __lr, __sp, -4));
-        emit(__mov_r(__AL, __pc, __lr));
+        emit(__blx(__AL, __lr));
         return;
     case OP_add:
         emit(__add_r(__AL, rd, rn, rm));


### PR DESCRIPTION
According to ["Arm Cortex-A53 MPCore Processor Technical Reference Manual"](https://developer.arm.com/documentation/ddi0500/j/Level-1-Memory-System/L1-Instruction-memory-system/Program-flow-prediction), the data-processing instructions using the PC as a destination register is not predicted.

After substituting the `MOV pc, ...` with `BLX` instruction, the statistics become:
```shell
Performance counter stats for 'out/shecc-stage1.elf -o e.out tests/fib.c' (5 runs):

         2,308,525      branches:u                                                    ( +-  0.00% )
           229,797      branch-misses:u           #    9.95% of all branches          ( +-  0.09% )

         0.0756673 +- 0.0000838 seconds time elapsed  ( +-  0.11% )
```

It reduces half of branch-misses and has ~4% speedup. The remaining part should be improved in the optimizer.

## Related Issues
-  #93