### PR TITLE
Refine Makefile on error handling for ARM32 architecture detection

### DIFF
--- a/mk/common.mk
+++ b/mk/common.mk
@@ -5,7 +5,7 @@ else
     PRINTF = env printf
 endif
 
-HOST_ARCH = $(shell arch)
+HOST_ARCH = $(shell arch 2>/dev/null)
 
 # Control the build verbosity
 ifeq ("$(VERBOSE)","1")


### PR DESCRIPTION
With the original Makefile, the host without `arch` in PATH gets "make: arch: No such file or directory" printed everytime while making, regardless which target is choosed. The `2>/dev/null` is added for suppressing the error message.