### PR TITLE
Report some context of an error

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -635,8 +635,12 @@ void global_release()
 
 void error(char *msg)
 {
+    char src[100];
+    strncpy(src, SOURCE+source_idx, 99);
+    src[99] = '\0';
+
     /* TODO: figure out the corresponding C source and report line number */
-    printf("Error %s at source location %d\n", msg, source_idx);
+    printf("Error %s at source location %d (%s)\n", msg, source_idx, src);
     abort();
 }
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -637,7 +637,7 @@ void error(char *msg)
 {
     char src[100];
     strncpy(src, SOURCE+source_idx, 99);
-    src[99] = '\0';
+    src[99] = 0;
 
     /* TODO: figure out the corresponding C source and report line number */
     printf("Error %s at source location %d (%s)\n", msg, source_idx, src);


### PR DESCRIPTION
Figuring out line numbers is hard, but printing the next N characters after the error position is easy, and is usually enough to find where it is using grep :)