### PR TITLE
Implement CSE and peephole optimization

### DIFF
--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -151,9 +151,6 @@ void cfg_flatten()
 
             ph2_ir_t *insn;
             for (insn = bb->ph2_ir_list.head; insn; insn = insn->next) {
-                if (insn->op == OP_assign && insn->dest == insn->src0)
-                    continue;
-
                 flatten_ir = add_ph2_ir(OP_generic);
                 memcpy(flatten_ir, insn, sizeof(ph2_ir_t));
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -299,6 +299,7 @@ typedef struct phi_operand phi_operand_t;
 
 struct insn {
     struct insn *next;
+    struct insn *prev;
     int idx;
     opcode_t opcode;
     var_t *rd;

--- a/src/defs.h
+++ b/src/defs.h
@@ -18,7 +18,7 @@
 #define MAX_FIELDS 32
 #define MAX_FUNCS 256
 #define MAX_FUNC_TRIES 1950
-#define MAX_BLOCKS 1050
+#define MAX_BLOCKS 1150
 #define MAX_TYPES 64
 #define MAX_IR_INSTR 36864
 #define MAX_BB_PRED 128

--- a/src/globals.c
+++ b/src/globals.c
@@ -576,6 +576,7 @@ void add_insn(block_t *block,
     else
         bb->insn_list.tail->next = n;
 
+    n->prev = bb->insn_list.tail;
     bb->insn_list.tail = n;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,9 @@
 /* Register allocator */
 #include "reg-alloc.c"
 
+/* Peephole optimization */
+#include "peephole.c"
+
 /* Machine code generation. support ARMv7-A and RISC-V32I */
 #include "codegen.c"
 
@@ -88,6 +91,8 @@ int main(int argc, char *argv[])
 
     /* allocate register from IR */
     reg_alloc();
+
+    peephole();
 
     /* flatten CFG to linear instruction */
     cfg_flatten();

--- a/src/main.c
+++ b/src/main.c
@@ -86,6 +86,9 @@ int main(int argc, char *argv[])
 
     ssa_build(dump_ir);
 
+    /* SSA-based optimization */
+    optimize();
+
     /* SSA-based liveness analyses */
     liveness_analysis();
 

--- a/src/peephole.c
+++ b/src/peephole.c
@@ -1,0 +1,73 @@
+/*
+ * shecc - Self-Hosting and Educational C Compiler.
+ *
+ * shecc is freely redistributable under the BSD 2 clause license. See the
+ * file "LICENSE" for information on usage and redistribution of this file.
+ */
+
+int is_fusible_insn(ph2_ir_t *ph2_ir)
+{
+    switch (ph2_ir->op) {
+    case OP_add:
+    case OP_sub:
+    case OP_mul:
+    case OP_div:
+    case OP_mod:
+    case OP_lshift:
+    case OP_rshift:
+    case OP_bit_and:
+    case OP_bit_or:
+    case OP_bit_xor:
+    case OP_log_and:
+    case OP_log_or:
+    case OP_log_not:
+    case OP_negate:
+    case OP_load:
+    case OP_global_load:
+    case OP_load_data_address:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+void insn_fusion(ph2_ir_t *ph2_ir)
+{
+    ph2_ir_t *next = ph2_ir->next;
+    if (!next)
+        return;
+
+    if (next->op == OP_assign) {
+        /* eliminate {ALU rn, rs1, rs2; mv rd, rn;} */
+        if (!is_fusible_insn(ph2_ir))
+            return;
+        if (ph2_ir->dest == next->src0) {
+            ph2_ir->dest = next->dest;
+            ph2_ir->next = next->next;
+            return;
+        }
+    }
+    /* other insn fusions */
+}
+
+/* FIXME: release detached basic blocks */
+void peephole()
+{
+    fn_t *fn;
+    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+        basic_block_t *bb;
+        for (bb = fn->bbs; bb; bb = bb->rpo_next) {
+            ph2_ir_t *ph2_ir;
+            for (ph2_ir = bb->ph2_ir_list.head; ph2_ir; ph2_ir = ph2_ir->next) {
+                ph2_ir_t *next = ph2_ir->next;
+                if (!next)
+                    continue;
+                if (next->op == OP_assign && next->dest == next->src0) {
+                    ph2_ir->next = next->next;
+                    continue;
+                }
+                insn_fusion(ph2_ir);
+            }
+        }
+    }
+}

--- a/src/ssa.c
+++ b/src/ssa.c
@@ -1051,6 +1051,84 @@ void ssa_build(int dump_ir)
     unwind_phi();
 }
 
+/* Common Subexpression Elimination (CSE) */
+/* TODO: simplify with def-use chain */
+/* TODO: release detached insns node */
+int cse(insn_t *insn, basic_block_t *bb)
+{
+    if (insn->opcode != OP_read)
+        return 0;
+
+    insn_t *prev = insn->prev;
+
+    if (!prev)
+        return 0;
+    if (prev->opcode != OP_add)
+        return 0;
+    if (prev->rd != insn->rs1)
+        return 0;
+
+    var_t *def = NULL, *base = prev->rs1, *idx = prev->rs2;
+    basic_block_t *b;
+    insn_t *i = prev;
+    for (b = bb;; b = b->idom) {
+        if (!i)
+            i = b->insn_list.tail;
+
+        for (; i; i = i->prev) {
+            if (i == prev)
+                continue;
+            if (i->opcode != OP_add)
+                continue;
+            if (!i->next)
+                continue;
+            if (i->next->opcode != OP_read)
+                continue;
+            if (i->rs1 != base || i->rs2 != idx)
+                continue;
+            def = i->next->rd;
+        }
+        if (def)
+            break;
+        if (b->idom == b)
+            break;
+    }
+
+    if (!def)
+        return 0;
+
+    if (prev->prev) {
+        insn->prev = prev->prev;
+        prev->next = insn;
+    } else {
+        bb->insn_list.head = insn;
+        insn->prev = NULL;
+    }
+
+    insn->opcode = OP_assign;
+    insn->rs1 = def;
+    return 1;
+}
+
+void optimize()
+{
+    int changed = 0;
+    fn_t *fn;
+    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+        /* basic block level (control flow) optimizations */
+
+        basic_block_t *bb;
+        for (bb = fn->bbs; bb; bb = bb->rpo_next) {
+            /* instruction level optimizations */
+            insn_t *insn;
+            for (insn = bb->insn_list.head; insn; insn = insn->next) {
+                changed |= cse(insn, bb);
+                /* more optimizations */
+            }
+        }
+    }
+}
+
 void bb_index_reversed_rpo(fn_t *fn, basic_block_t *bb)
 {
     bb->rpo_r = fn->bb_cnt++;

--- a/src/ssa.c
+++ b/src/ssa.c
@@ -651,18 +651,16 @@ void append_unwound_phi_insn(basic_block_t *bb, var_t *dest, var_t *rs)
     } else {
         /* insert it before branch instruction */
         if (tail->opcode == OP_branch) {
-            insn_t *prev = bb->insn_list.head;
-            if (!prev->next) {
+            if (tail->prev) {
+                tail->prev->next = n;
+                n->prev = tail->prev;
+            } else
                 bb->insn_list.head = n;
-                n->next = prev;
-            } else {
-                while (prev->next != tail)
-                    prev = prev->next;
-                prev->next = n;
-                n->next = tail;
-            }
+
+            n->next = tail;
+            tail->prev = n;
         } else {
-            bb->insn_list.tail->next = n;
+            tail->next = n;
             bb->insn_list.tail = n;
         }
     }


### PR DESCRIPTION
## Peephole optimization

The `MOV` after arithmetical or `LOAD` instruction is redundant. Simply assign the result to the destination register of the `MOV` instruction.

For example, the generated ARMv7 instructions of the statement `t = 1 + 2 + 4 + 8` after optimizing are:

```diff
  mov	r0, 1
  mov	r1, 2
  add	r2, r0, r1
  mov	r0, 4
  add	r1, r2, r0
  mov	r0, 8
- add	r2, r1, r0
- mov	r0, r2
+ add	r0, r1, r0
```

The `r0` register in last two instructions is reused and eliminates the redundant `MOV` instruction.

## CSE (common subexpression elimination)

Reuse the read data if it came from the same location of memory. For example, the following code references the same element of array:

```c
int main()
{
    char arr[1];
    int i, t, pos = 0;
    for (i = 0; i < 10000000; i++)
        t = arr[pos] + arr[pos];
    return 0;
}
```

After the optimization, the common statement `arr[pos]` was substituted by coping the read result.

```diff
  ldr	r0, [sp, 4]
  ldr	r1, [sp, 9]
  add	r2, r0, r1
  ldrb	r3, [r2]
  add	r2, r0, r1
- ldrb	r4, [r2]
- add	r3, r3, r4
+ mov	r2, r3
+ add	r2, r3, r2
```

It approximately reduces 5% run time on Raspberry Pi 3B.

The CSE is done before the liveness analysis. But the DCE (dead code elimination) is related to the traversal of liveness analysis, the implementation needs more improvement and is postponed.

## Related issues:
- #88