### PR TITLE
Migrate preprocessor directive handling

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -68,15 +68,15 @@ typedef enum {
     T_break,
     T_default,
     T_continue,
-    T_preproc_include,
-    T_preproc_define,
-    T_preproc_undef,
-    T_preproc_error,
-    T_preproc_if,
-    T_preproc_elif,
-    T_preproc_else,
-    T_preproc_endif,
-    T_preproc_ifdef
+    T_cppd_include,
+    T_cppd_define,
+    T_cppd_undef,
+    T_cppd_error,
+    T_cppd_if,
+    T_cppd_elif,
+    T_cppd_else,
+    T_cppd_endif,
+    T_cppd_ifdef
 } token_t;
 
 char token_str[MAX_TOKEN_LEN];
@@ -225,31 +225,31 @@ token_t get_next_token()
         skip_whitespace();
 
         if (!strcmp(token_str, "#include")) {
-            return T_preproc_include;
+            return T_cppd_include;
         }
         if (!strcmp(token_str, "#define")) {
-            return T_preproc_define;
+            return T_cppd_define;
         }
         if (!strcmp(token_str, "#undef")) {
-            return T_preproc_undef;
+            return T_cppd_undef;
         }
         if (!strcmp(token_str, "#error")) {
-            return T_preproc_error;
+            return T_cppd_error;
         }
         if (!strcmp(token_str, "#if")) {
-            return T_preproc_if;
+            return T_cppd_if;
         }
         if (!strcmp(token_str, "#elif")) {
-            return T_preproc_elif;
+            return T_cppd_elif;
         }
         if (!strcmp(token_str, "#ifdef")) {
-            return T_preproc_ifdef;
+            return T_cppd_ifdef;
         }
         if (!strcmp(token_str, "#else")) {
-            return T_preproc_else;
+            return T_cppd_else;
         }
         if (!strcmp(token_str, "#endif")) {
-            return T_preproc_endif;
+            return T_cppd_endif;
         }
         error("Unknown directive");
     }
@@ -605,10 +605,10 @@ int lex_accept(token_t token)
 {
     if (next_token == token) {
         /* FIXME: this is a hack, fix aggressive aliasing first */
-        if (token == T_preproc_ifdef)
+        if (token == T_cppd_ifdef)
             preproc_aliasing = 0;
         next_token = get_next_token();
-        if (token == T_preproc_ifdef)
+        if (token == T_cppd_ifdef)
             preproc_aliasing = 1;
         return 1;
     }

--- a/src/parser.c
+++ b/src/parser.c
@@ -95,8 +95,8 @@ void if_elif_skip_lines()
 
 void ifdef_else_skip_lines()
 {
-    while (!lex_peek(T_preproc_else, NULL) &&
-           !lex_peek(T_preproc_endif, NULL)) {
+    while (!lex_peek(T_cppd_else, NULL) &&
+           !lex_peek(T_cppd_endif, NULL)) {
         next_token = get_next_token();
     }
     skip_whitespace();
@@ -129,14 +129,14 @@ int read_preproc_directive()
 {
     char token[MAX_ID_LEN];
 
-    if (lex_peek(T_preproc_include, token)) {
+    if (lex_peek(T_cppd_include, token)) {
         skip_line(0); /* FIXME: remove this line after syntax parsing is
                          implemented */
-        lex_expect(T_preproc_include);
+        lex_expect(T_cppd_include);
         /* TODO: parse include syntax here */
         return 1;
     }
-    if (lex_accept(T_preproc_define)) {
+    if (lex_accept(T_cppd_define)) {
         char alias[MAX_VAR_LEN];
         char value[MAX_VAR_LEN];
 
@@ -167,11 +167,11 @@ int read_preproc_directive()
 
         return 1;
     }
-    if (lex_peek(T_preproc_undef, token)) {
+    if (lex_peek(T_cppd_undef, token)) {
         char alias[MAX_VAR_LEN];
 
         preproc_aliasing = 0;
-        lex_expect(T_preproc_undef);
+        lex_expect(T_cppd_undef);
         lex_peek(T_identifier, alias);
         preproc_aliasing = 1;
         lex_expect(T_identifier);
@@ -180,7 +180,7 @@ int read_preproc_directive()
         remove_macro(alias);
         return 1;
     }
-    if (lex_peek(T_preproc_error, NULL)) {
+    if (lex_peek(T_cppd_error, NULL)) {
         int i = 0;
         char error_diagnostic[MAX_LINE_LEN];
 
@@ -191,7 +191,7 @@ int read_preproc_directive()
 
         error(error_diagnostic);
     }
-    if (lex_accept(T_preproc_if)) {
+    if (lex_accept(T_cppd_if)) {
         preproc_match = 0;
 
         if (lex_peek(T_identifier, token) && !strcmp(token, "defined")) {
@@ -208,9 +208,9 @@ int read_preproc_directive()
         }
         return 1;
     }
-    if (lex_accept(T_preproc_elif)) {
+    if (lex_accept(T_cppd_elif)) {
         if (preproc_match) {
-            while (!lex_peek(T_preproc_endif, NULL)) {
+            while (!lex_peek(T_cppd_endif, NULL)) {
                 next_token = get_next_token();
             }
             return 1;
@@ -231,7 +231,7 @@ int read_preproc_directive()
 
         return 1;
     }
-    if (lex_accept(T_preproc_else)) {
+    if (lex_accept(T_cppd_else)) {
         /* reach here has 2 possible cases:
          * 1. reach #ifdef preprocessor directive
          * 2. conditional expression in #elif is false
@@ -245,12 +245,12 @@ int read_preproc_directive()
         ifdef_else_skip_lines();
         return 1;
     }
-    if (lex_accept(T_preproc_endif)) {
+    if (lex_accept(T_cppd_endif)) {
         preproc_match = 0;
         skip_whitespace();
         return 1;
     }
-    if (lex_accept(T_preproc_ifdef)) {
+    if (lex_accept(T_cppd_ifdef)) {
         preproc_match = 0;
         lex_ident(T_identifier, token);
         check_def(token);

--- a/src/parser.c
+++ b/src/parser.c
@@ -62,12 +62,14 @@ int get_size(var_t *var, type_t *type)
     return type->size;
 }
 
-/* abort when invalidate is true and the line contains  character other than whitespace */
+/* abort when invalidate is true and the line contains  character other than
+ * whitespace */
 void skip_line(int invalidate)
 {
     skip_whitespace();
     do {
-        if (invalidate && !is_whitespace(peek_char(0)) && !is_newline(peek_char(0))) {
+        if (invalidate && !is_whitespace(peek_char(0)) &&
+            !is_newline(peek_char(0))) {
             error("Expects whitespace after preprocessor directive");
         }
     } while (read_char(0) != '\n');
@@ -93,7 +95,8 @@ void if_elif_skip_lines()
 
 void ifdef_else_skip_lines()
 {
-    while (!lex_peek(T_preproc_else, NULL) && !lex_peek(T_preproc_endif, NULL)) {
+    while (!lex_peek(T_preproc_else, NULL) &&
+           !lex_peek(T_preproc_endif, NULL)) {
         next_token = get_next_token();
     }
     skip_whitespace();
@@ -109,7 +112,7 @@ void read_defined_macro()
 {
     char lookup_alias[MAX_TOKEN_LEN];
 
-    preproc_aliasing = 0; /* to prevent aggressive aliasing */
+    preproc_aliasing = 0;     /* to prevent aggressive aliasing */
     lex_expect(T_identifier); /* defined */
     lex_expect(T_open_bracket);
     lex_ident(T_identifier, lookup_alias);
@@ -127,7 +130,8 @@ int read_preproc_directive()
     char token[MAX_ID_LEN];
 
     if (lex_peek(T_preproc_include, token)) {
-        skip_line(0); /* FIXME: remove this line after syntax parsing is implemented */
+        skip_line(0); /* FIXME: remove this line after syntax parsing is
+                         implemented */
         lex_expect(T_preproc_include);
         /* TODO: parse include syntax here */
         return 1;

--- a/src/parser.c
+++ b/src/parser.c
@@ -95,8 +95,7 @@ void if_elif_skip_lines()
 
 void ifdef_else_skip_lines()
 {
-    while (!lex_peek(T_cppd_else, NULL) &&
-           !lex_peek(T_cppd_endif, NULL)) {
+    while (!lex_peek(T_cppd_else, NULL) && !lex_peek(T_cppd_endif, NULL)) {
         next_token = get_next_token();
     }
     skip_whitespace();

--- a/src/parser.c
+++ b/src/parser.c
@@ -2593,9 +2593,6 @@ void read_global_statement()
     char token[MAX_ID_LEN];
     block_t *block = &BLOCKS[0]; /* global block */
 
-    if (read_preproc_directive())
-        return;
-
     if (lex_accept(T_struct)) {
         int i = 0, size = 0;
 
@@ -2756,6 +2753,8 @@ void parse_internal()
     lex_expect(T_start);
 
     do {
+        if (read_preproc_directive())
+            continue;
         read_global_statement();
     } while (!lex_accept(T_eof));
 }


### PR DESCRIPTION
This pull request migrates preprocessor directive handling to parser unit, which unify the behaviour of lexer unit by only handling lexical analysis. This also improves preprocessor directive parsing by processing it with token instead of raw string.

Notice that in this pull request, there are several hacks were introduced due to previous faulty design (See `lexer.c#lex_accept`).

This pull request is part of  #84.