### PR TITLE
Report additional context when error panicking

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -636,8 +636,27 @@ void global_release()
 
 void error(char *msg)
 {
-    /* TODO: figure out the corresponding C source and report line number */
-    printf("Error %s at source location %d\n", msg, source_idx);
+    /* Construct error source diagnostic */
+    int offset, start_idx, i = 0;
+    char diagnostic[512 /* MAX_LINE_LEN * 2 */];
+
+    for (offset = source_idx; offset >= 0 && SOURCE[offset] != '\n'; offset--);
+
+    start_idx = offset + 1;
+    
+    for (offset = 0; offset < MAX_SOURCE && SOURCE[start_idx + offset] != '\n'; offset++) {
+        diagnostic[i++] = SOURCE[start_idx + offset];
+    }
+    diagnostic[i++] = '\n';
+
+    for (offset = start_idx; offset < source_idx; offset++) {
+        diagnostic[i++] = ' ';
+    }
+
+    strcpy(diagnostic + i, "^ Error occurs here");
+
+    /* TODO: figure out the corresponding C source file path and report line number */
+    printf("Error %s at source location %d\n%s\n", msg, source_idx, diagnostic);
     abort();
 }
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -640,11 +640,13 @@ void error(char *msg)
     int offset, start_idx, i = 0;
     char diagnostic[512 /* MAX_LINE_LEN * 2 */];
 
-    for (offset = source_idx; offset >= 0 && SOURCE[offset] != '\n'; offset--);
+    for (offset = source_idx; offset >= 0 && SOURCE[offset] != '\n'; offset--)
+        ;
 
     start_idx = offset + 1;
-    
-    for (offset = 0; offset < MAX_SOURCE && SOURCE[start_idx + offset] != '\n'; offset++) {
+
+    for (offset = 0; offset < MAX_SOURCE && SOURCE[start_idx + offset] != '\n';
+         offset++) {
         diagnostic[i++] = SOURCE[start_idx + offset];
     }
     diagnostic[i++] = '\n';
@@ -655,7 +657,8 @@ void error(char *msg)
 
     strcpy(diagnostic + i, "^ Error occurs here");
 
-    /* TODO: figure out the corresponding C source file path and report line number */
+    /* TODO: figure out the corresponding C source file path and report line
+     * number */
     printf("Error %s at source location %d\n%s\n", msg, source_idx, diagnostic);
     abort();
 }

--- a/src/globals.c
+++ b/src/globals.c
@@ -636,7 +636,8 @@ void global_release()
 
 void error(char *msg)
 {
-    /* Construct error source diagnostic */
+    /* Construct error source diagnostics, enabling precise identification of
+     * syntax and logic issues within the code. */
     int offset, start_idx, i = 0;
     char diagnostic[512 /* MAX_LINE_LEN * 2 */];
 


### PR DESCRIPTION
In previous design, calling `error(char *msg)` in `globals.c` will only show context of error and `source_idx`, which is hard for both developer and contributor to locate the source of error.

In this PR, error message will also show the 1 line of source code and the exact character position where the error occurs.   

```diff
  Error ERR_TEST at source location 100
+ #include <stdlib.h>
+    ^ Error occurs here
```