### PR TITLE
Fix unsafely CSE for global variable

### DIFF
--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -547,4 +547,23 @@ int main()
 }
 EOF
 
+# optimizer
+try_ 1 << EOF
+int i = 0;
+void func()
+{
+    i = 1;
+}
+int main()
+{
+    char arr[2], t;
+    arr[0] = 0;
+    arr[1] = 1;
+    t = arr[i];
+    func();
+    t = arr[i];
+    return t;
+}
+EOF
+
 echo OK


### PR DESCRIPTION
The global variable might be changed by the subroutine. Considering the following code:

```c
int e = arr[idx];
subroutine_changing_idx();
int d = arr[idx];
```

We cannot invoke the CSE and replace `d = arr[idx]` with `d = e` safely here.
