### PR TITLE
Implement constant optimization

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -16,8 +16,8 @@
 #define MAX_PARAMS 8
 #define MAX_LOCALS 1450
 #define MAX_FIELDS 32
-#define MAX_FUNCS 256
-#define MAX_FUNC_TRIES 1950
+#define MAX_FUNCS 512
+#define MAX_FUNC_TRIES 2160
 #define MAX_BLOCKS 1150
 #define MAX_TYPES 64
 #define MAX_IR_INSTR 36864
@@ -175,6 +175,7 @@ struct var {
     ref_block_list_t ref_block_list; /* blocks which kill variable */
     int consumed;
     int is_ternary_ret;
+    int is_const; /* whether a constant representaion or not */
 };
 
 typedef struct var var_t;

--- a/src/parser.c
+++ b/src/parser.c
@@ -28,6 +28,7 @@ var_t *require_var(block_t *blk)
         error("Too many locals");
 
     var_t *var = &blk->locals[blk->next_local++];
+    var->consumed = -1;
     var->base = var;
     return var;
 }

--- a/src/ssa.c
+++ b/src/ssa.c
@@ -1111,6 +1111,87 @@ int cse(insn_t *insn, basic_block_t *bb)
     return 1;
 }
 
+int mark_const(insn_t *insn)
+{
+    if (insn->opcode == OP_load_constant) {
+        insn->rd->is_const = 1;
+        return 0;
+    }
+    if (insn->opcode != OP_assign)
+        return 0;
+    /* The global variable is unique and has no subscripts in our SSA. Do NOT
+     * evaluate its value.
+     */
+    if (insn->rd->is_global)
+        return 0;
+    if (!insn->rs1->is_const) {
+        if (!insn->prev)
+            return 0;
+        if (insn->prev->opcode != OP_load_constant)
+            return 0;
+        if (insn->rs1 != insn->prev->rd)
+            return 0;
+    }
+
+    insn->opcode = OP_load_constant;
+    insn->rd->is_const = 1;
+    insn->rd->init_val = insn->rs1->init_val;
+    insn->rs1 = NULL;
+    return 1;
+}
+
+int eval_const_arithmetic(insn_t *insn)
+{
+    if (!insn->rs1)
+        return 0;
+    if (!insn->rs1->is_const)
+        return 0;
+    if (!insn->rs2)
+        return 0;
+    if (!insn->rs2->is_const)
+        return 0;
+
+    int res;
+    int l = insn->rs1->init_val;
+    int r = insn->rs2->init_val;
+
+    switch (insn->opcode) {
+    case OP_add:
+        res = l + r;
+        break;
+    case OP_sub:
+        res = l - r;
+        break;
+    case OP_mul:
+        res = l * r;
+        break;
+    case OP_div:
+        res = l / r;
+        break;
+    case OP_mod:
+        res = l % r;
+        break;
+    default:
+        return 0;
+    }
+
+    insn->rs1 = NULL;
+    insn->rs2 = NULL;
+    insn->rd->is_const = 1;
+    insn->rd->init_val = res;
+    insn->opcode = OP_load_constant;
+    return 1;
+}
+
+int const_folding(insn_t *insn)
+{
+    if (mark_const(insn))
+        return 1;
+    if (eval_const_arithmetic(insn))
+        return 1;
+    return 0;
+}
+
 void optimize()
 {
     fn_t *fn;
@@ -1124,7 +1205,8 @@ void optimize()
             for (insn = bb->insn_list.head; insn; insn = insn->next) {
                 if (cse(insn, bb))
                     continue;
-
+                if (const_folding(insn))
+                    continue;
                 /* more optimizations */
             }
         }

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -578,5 +578,6 @@ int main()
     int d = c + 8;        /* mixed assigment */
     return a + b + c + d; /* chained assignment */
 }
+EOF
 
 echo OK

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -547,7 +547,9 @@ int main()
 }
 EOF
 
-# optimizer
+# optimizers
+
+# common subexpression elimination (CSE)
 try_ 1 << EOF
 int i = 0;
 void func()
@@ -565,5 +567,16 @@ int main()
     return t;
 }
 EOF
+
+# constant folding
+try_ 20 << EOF
+int main()
+{
+    int a = 2;            /* constant assingment */
+    int b = a;            /* assignment via constant representation */
+    int c = a + b;
+    int d = c + 8;        /* mixed assigment */
+    return a + b + c + d; /* chained assignment */
+}
 
 echo OK


### PR DESCRIPTION
Consider the following scenario:

```c
int a = 2;            /* constant assingment */
int b = a;            /* assignment via constant representation */
int c = a + b;
int d = c + 8;        /* mixed assigment */
return a + b + c + d; /* chained assignment */
```

The current code generator emits the assembly below, even though the variables a, b, c, d are all constant representations.

```assembly
mov     r0, #2
mov     r1, r0
mov     r0, r1
add     r3, r1, r0
mov     r2, #8
add     r2, r3, r2
add     r4, r1, r0
add     r0, r4, r3
add     r1, r0, r2
mov     r0, r1
```

The new constant optimizer will evaluate the constant representations, trim the unused variables, and emit `mov r0, #20` only.