### PR TITLE
Enforce C99 to improve readability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 CFLAGS := -O -g \
-	-ansi -pedantic \
+	-std=c99 -pedantic \
 	-Wall -Wextra \
 	-Wno-unused-but-set-variable \
 	-Wno-variadic-macros \

--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -125,32 +125,29 @@ void cfg_flatten()
     elf_offset = 80; /* offset of start + exit + syscall in codegen */
     GLOBAL_FUNC.fn->bbs->elf_offset = elf_offset;
 
-    ph2_ir_t *ph2_ir;
-    for (ph2_ir = GLOBAL_FUNC.fn->bbs->ph2_ir_list.head; ph2_ir;
+    for (ph2_ir_t *ph2_ir = GLOBAL_FUNC.fn->bbs->ph2_ir_list.head; ph2_ir;
          ph2_ir = ph2_ir->next)
         update_elf_offset(ph2_ir);
 
     /* prepare `argc` and `argv`, then proceed to `main` function */
     elf_offset += 24;
 
-    fn_t *fn;
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         ph2_ir_t *flatten_ir;
 
         /* reserve stack */
         flatten_ir = add_ph2_ir(OP_define);
         flatten_ir->src0 = fn->func->stack_size;
 
-        basic_block_t *bb;
-        for (bb = fn->bbs; bb; bb = bb->rpo_next) {
+        for (basic_block_t *bb = fn->bbs; bb; bb = bb->rpo_next) {
             bb->elf_offset = elf_offset;
 
             if (bb == fn->bbs)
                 /* save ra, sp */
                 elf_offset += 16;
 
-            ph2_ir_t *insn;
-            for (insn = bb->ph2_ir_list.head; insn; insn = insn->next) {
+            for (ph2_ir_t *insn = bb->ph2_ir_list.head; insn;
+                 insn = insn->next) {
                 flatten_ir = add_ph2_ir(OP_generic);
                 memcpy(flatten_ir, insn, sizeof(ph2_ir_t));
 
@@ -426,8 +423,7 @@ void code_generate()
     emit(__add_i(__AL, __r1, __r8, 4));
     emit(__b(__AL, MAIN_BB->elf_offset - elf_code_idx));
 
-    int i;
-    for (i = 0; i < ph2_ir_idx; i++) {
+    for (int i = 0; i < ph2_ir_idx; i++) {
         ph2_ir = &PH2_IR[i];
         emit_ph2_ir(ph2_ir);
     }

--- a/src/arm.c
+++ b/src/arm.c
@@ -97,13 +97,11 @@ arm_cond_t arm_get_cond(opcode_t op)
 
 int arm_extract_bits(int imm, int i_start, int i_end, int d_start, int d_end)
 {
-    int v;
-
     if (((d_end - d_start) != (i_end - i_start)) || (i_start > i_end) ||
         (d_start > d_end))
         error("Invalid bit copy");
 
-    v = imm >> i_start;
+    int v = imm >> i_start;
     v = v & ((2 << (i_end - i_start)) - 1);
     v = v << d_start;
     return v;

--- a/src/elf.c
+++ b/src/elf.c
@@ -14,15 +14,13 @@ int elf_section_index;
 
 void elf_write_section_str(char *vals, int len)
 {
-    int i;
-    for (i = 0; i < len; i++)
+    for (int i = 0; i < len; i++)
         elf_section[elf_section_index++] = vals[i];
 }
 
 void elf_write_data_str(char *vals, int len)
 {
-    int i;
-    for (i = 0; i < len; i++)
+    for (int i = 0; i < len; i++)
         elf_data[elf_data_idx++] = vals[i];
 }
 
@@ -43,8 +41,7 @@ char e_extract_byte(int v, int b)
 
 int elf_write_int(char *buf, int index, int val)
 {
-    int i = 0;
-    for (i = 0; i < 4; i++)
+    for (int i = 0; i < 4; i++)
         buf[index++] = e_extract_byte(val, i);
     return index;
 }
@@ -118,12 +115,11 @@ void elf_generate_header()
 void elf_generate_sections()
 {
     /* symtab section */
-    int b;
-    for (b = 0; b < elf_symtab_index; b++)
+    for (int b = 0; b < elf_symtab_index; b++)
         elf_write_section_byte(elf_symtab[b]);
 
     /* strtab section */
-    for (b = 0; b < elf_strtab_index; b++)
+    for (int b = 0; b < elf_strtab_index; b++)
         elf_write_section_byte(elf_strtab[b]);
 
     /* shstr section; len = 39 */
@@ -246,9 +242,6 @@ void elf_add_symbol(char *symbol, int len, int pc)
 
 void elf_generate(char *outfile)
 {
-    FILE *fp;
-    int i;
-
     elf_symbol_index = 0;
     elf_symtab_index = 0;
     elf_strtab_index = 0;
@@ -261,14 +254,14 @@ void elf_generate(char *outfile)
     if (!outfile)
         outfile = "a.out";
 
-    fp = fopen(outfile, "wb");
-    for (i = 0; i < elf_header_idx; i++)
+    FILE *fp = fopen(outfile, "wb");
+    for (int i = 0; i < elf_header_idx; i++)
         fputc(elf_header[i], fp);
-    for (i = 0; i < elf_code_idx; i++)
+    for (int i = 0; i < elf_code_idx; i++)
         fputc(elf_code[i], fp);
-    for (i = 0; i < elf_data_idx; i++)
+    for (int i = 0; i < elf_data_idx; i++)
         fputc(elf_data[i], fp);
-    for (i = 0; i < elf_section_index; i++)
+    for (int i = 0; i < elf_section_index; i++)
         fputc(elf_section[i], fp);
     fclose(fp);
 }

--- a/src/globals.c
+++ b/src/globals.c
@@ -89,7 +89,6 @@ int insert_trie(trie_t *trie, char *name, int funcs_index)
 {
     char first_char = *name;
     int fc = first_char;
-    int i;
     if (!fc) {
         if (!trie->index)
             trie->index = funcs_index;
@@ -102,7 +101,7 @@ int insert_trie(trie_t *trie, char *name, int funcs_index)
          * handle this is to dynamically allocate a new element.
          */
         trie->next[fc] = func_tries_idx++;
-        for (i = 0; i < 128; i++)
+        for (int i = 0; i < 128; i++)
             FUNC_TRIES[trie->next[fc]].next[i] = 0;
         FUNC_TRIES[trie->next[fc]].index = 0;
     }
@@ -146,8 +145,7 @@ int dump_ir = 0;
  */
 type_t *find_type(char *type_name, int flag)
 {
-    int i;
-    for (i = 0; i < types_idx; i++) {
+    for (int i = 0; i < types_idx; i++) {
         if (TYPES[i].base_type == TYPE_struct) {
             if (flag == 1)
                 continue;
@@ -207,8 +205,7 @@ void add_label(char *name, int offset)
 
 int find_label_offset(char name[])
 {
-    int i;
-    for (i = 0; i < label_lut_idx; i++) {
+    for (int i = 0; i < label_lut_idx; i++) {
         if (!strcmp(LABEL_LUT[i].name, name))
             return LABEL_LUT[i].offset;
     }
@@ -236,8 +233,7 @@ void add_alias(char *alias, char *value)
 
 char *find_alias(char alias[])
 {
-    int i;
-    for (i = 0; i < aliases_idx; i++) {
+    for (int i = 0; i < aliases_idx; i++) {
         if (!ALIASES[i].disabled && !strcmp(alias, ALIASES[i].alias))
             return ALIASES[i].value;
     }
@@ -246,8 +242,7 @@ char *find_alias(char alias[])
 
 int remove_alias(char *alias)
 {
-    int i;
-    for (i = 0; i < aliases_idx; i++) {
+    for (int i = 0; i < aliases_idx; i++) {
         if (!ALIASES[i].disabled && !strcmp(alias, ALIASES[i].alias)) {
             ALIASES[i].disabled = 1;
             return 1;
@@ -266,8 +261,7 @@ macro_t *add_macro(char *name)
 
 macro_t *find_macro(char *name)
 {
-    int i;
-    for (i = 0; i < macros_idx; i++) {
+    for (int i = 0; i < macros_idx; i++) {
         if (!MACROS[i].disabled && !strcmp(name, MACROS[i].name))
             return &MACROS[i];
     }
@@ -276,8 +270,7 @@ macro_t *find_macro(char *name)
 
 int remove_macro(char *name)
 {
-    int i;
-    for (i = 0; i < macros_idx; i++) {
+    for (int i = 0; i < macros_idx; i++) {
         if (!MACROS[i].disabled && !strcmp(name, MACROS[i].name)) {
             MACROS[i].disabled = 1;
             return 1;
@@ -289,7 +282,6 @@ int remove_macro(char *name)
 void error(char *msg);
 int find_macro_param_src_idx(char *name, block_t *parent)
 {
-    int i;
     macro_t *macro = parent->macro;
 
     if (!parent)
@@ -297,7 +289,7 @@ int find_macro_param_src_idx(char *name, block_t *parent)
     if (!parent->macro)
         return 0;
 
-    for (i = 0; i < macro->num_param_defs; i++) {
+    for (int i = 0; i < macro->num_param_defs; i++) {
         if (!strcmp(macro->param_defs[i].var_name, name))
             return macro->params[i];
     }
@@ -338,8 +330,7 @@ void add_constant(char alias[], int value)
 
 constant_t *find_constant(char alias[])
 {
-    int i;
-    for (i = 0; i < constants_idx; i++) {
+    for (int i = 0; i < constants_idx; i++) {
         if (!strcmp(CONSTANTS[i].alias, alias))
             return &CONSTANTS[i];
     }
@@ -363,8 +354,7 @@ var_t *find_member(char token[], type_t *type)
     if (type->size == 0)
         type = type->base_struct;
 
-    int i;
-    for (i = 0; i < type->num_fields; i++) {
+    for (int i = 0; i < type->num_fields; i++) {
         if (!strcmp(type->fields[i].var_name, token))
             return &type->fields[i];
     }
@@ -373,18 +363,17 @@ var_t *find_member(char token[], type_t *type)
 
 var_t *find_local_var(char *token, block_t *block)
 {
-    int i;
     func_t *fn = block->func;
 
     for (; block; block = block->parent) {
-        for (i = 0; i < block->next_local; i++) {
+        for (int i = 0; i < block->next_local; i++) {
             if (!strcmp(block->locals[i].var_name, token))
                 return &block->locals[i];
         }
     }
 
     if (fn) {
-        for (i = 0; i < fn->num_params; i++) {
+        for (int i = 0; i < fn->num_params; i++) {
             if (!strcmp(fn->param_defs[i].var_name, token))
                 return &fn->param_defs[i];
         }
@@ -394,10 +383,9 @@ var_t *find_local_var(char *token, block_t *block)
 
 var_t *find_global_var(char *token)
 {
-    int i;
     block_t *block = &BLOCKS[0];
 
-    for (i = 0; i < block->next_local; i++) {
+    for (int i = 0; i < block->next_local; i++) {
         if (!strcmp(block->locals[i].var_name, token))
             return &block->locals[i];
     }
@@ -451,8 +439,7 @@ basic_block_t *bb_create(block_t *parent)
 {
     basic_block_t *bb = calloc(1, sizeof(basic_block_t));
 
-    int i;
-    for (i = 0; i < MAX_BB_PRED; i++) {
+    for (int i = 0; i < MAX_BB_PRED; i++) {
         bb->prev[i].bb = NULL;
         bb->prev[i].type = NEXT;
     }
@@ -501,8 +488,7 @@ void bb_connect(basic_block_t *pred,
 /* The pred-succ pair must have only one connection */
 void bb_disconnect(basic_block_t *pred, basic_block_t *succ)
 {
-    int i;
-    for (i = 0; i < MAX_BB_PRED; i++) {
+    for (int i = 0; i < MAX_BB_PRED; i++) {
         if (succ->prev[i].bb == pred) {
             switch (succ->prev[i].type) {
             case NEXT:
@@ -666,8 +652,7 @@ void error(char *msg)
 
 void print_indent(int indent)
 {
-    int i;
-    for (i = 0; i < indent; i++)
+    for (int i = 0; i < indent; i++)
         printf("\t");
 }
 
@@ -676,10 +661,9 @@ void dump_ph1_ir()
     int indent = 0;
     ph1_ir_t *ph1_ir;
     func_t *fn;
-    int i, j, k;
     char rd[MAX_VAR_LEN], op1[MAX_VAR_LEN], op2[MAX_VAR_LEN];
 
-    for (i = 0; i < ph1_ir_idx; i++) {
+    for (int i = 0; i < ph1_ir_idx; i++) {
         ph1_ir = &PH1_IR[i];
 
         if (ph1_ir->dest)
@@ -694,16 +678,16 @@ void dump_ph1_ir()
             fn = find_func(ph1_ir->func_name);
             printf("def %s", fn->return_def.type_name);
 
-            for (j = 0; j < fn->return_def.is_ptr; j++)
+            for (int j = 0; j < fn->return_def.is_ptr; j++)
                 printf("*");
             printf(" @%s(", ph1_ir->func_name);
 
-            for (j = 0; j < fn->num_params; j++) {
+            for (int j = 0; j < fn->num_params; j++) {
                 if (j != 0)
                     printf(", ");
                 printf("%s", fn->param_defs[j].type_name);
 
-                for (k = 0; k < fn->param_defs[j].is_ptr; k++)
+                for (int k = 0; k < fn->param_defs[j].is_ptr; k++)
                     printf("*");
                 printf(" %%%s", fn->param_defs[j].var_name);
             }
@@ -722,7 +706,7 @@ void dump_ph1_ir()
         case OP_allocat:
             print_indent(indent);
             printf("allocat %s", ph1_ir->src0->type_name);
-            for (j = 0; j < ph1_ir->src0->is_ptr; j++)
+            for (int j = 0; j < ph1_ir->src0->is_ptr; j++)
                 printf("*");
             printf(" %%%s", op1);
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -130,12 +130,12 @@ int is_hex(char c)
 
 int is_numeric(char buffer[])
 {
-    int i, hex = 0, size = strlen(buffer);
+    int hex = 0, size = strlen(buffer);
 
     if (size > 2)
         hex = (buffer[0] == '0' && buffer[1] == 'x') ? 1 : 0;
 
-    for (i = 0; i < size; i++) {
+    for (int i = 0; i < size; i++) {
         if (hex && (is_hex(buffer[i]) == 0))
             return 0;
         if (!hex && (is_digit(buffer[i]) == 0))

--- a/src/main.c
+++ b/src/main.c
@@ -46,9 +46,8 @@ int main(int argc, char *argv[])
 {
     int libc = 1;
     char *out = NULL, *in = NULL;
-    int i;
 
-    for (i = 1; i < argc; i++) {
+    for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "--dump-ir"))
             dump_ir = 1;
         else if (!strcmp(argv[i], "--no-libc"))

--- a/src/parser.c
+++ b/src/parser.c
@@ -670,7 +670,7 @@ void read_char_param(block_t *parent, basic_block_t *bb)
 void read_ternary_operation(block_t *parent, basic_block_t **bb);
 void read_func_parameters(block_t *parent, basic_block_t **bb)
 {
-    int i, param_num = 0;
+    int param_num = 0;
     var_t *params[MAX_PARAMS];
 
     lex_expect(T_open_bracket);
@@ -681,7 +681,7 @@ void read_func_parameters(block_t *parent, basic_block_t **bb)
         params[param_num++] = opstack_pop();
         lex_accept(T_comma);
     }
-    for (i = 0; i < param_num; i++) {
+    for (int i = 0; i < param_num; i++) {
         ph1_ir_t *ph1_ir = add_ph1_ir(OP_push);
         ph1_ir->src0 = params[i];
         /* The operand should keep alive before calling function. Pass the
@@ -868,7 +868,7 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
 
         if (!strcmp(token, "__VA_ARGS__")) {
             /* `source_idx` has pointed at the character after __VA_ARGS__ */
-            int i, remainder, t = source_idx;
+            int remainder, t = source_idx;
             macro_t *macro = parent->macro;
 
             if (!macro)
@@ -877,7 +877,7 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
                 error("Unexpected identifier '__VA_ARGS__'");
 
             remainder = macro->num_params - macro->num_param_defs;
-            for (i = 0; i < remainder; i++) {
+            for (int i = 0; i < remainder; i++) {
                 source_idx = macro->params[macro->num_params - remainder + i];
                 next_char = SOURCE[source_idx];
                 next_token = lex_token();
@@ -1913,8 +1913,7 @@ basic_block_t *continue_bb[MAX_NESTING];
 
 void perform_side_effect(block_t *parent, basic_block_t *bb)
 {
-    int i;
-    for (i = 0; i < se_idx; i++) {
+    for (int i = 0; i < se_idx; i++) {
         ph1_ir_t *ph1_ir = add_ph1_ir(side_effect[i].op);
         memcpy(ph1_ir, &side_effect[i], sizeof(ph1_ir_t));
         add_insn(parent, bb, ph1_ir->op, ph1_ir->dest, ph1_ir->src0,
@@ -2288,8 +2287,8 @@ basic_block_t *read_body_statement(block_t *parent, basic_block_t *bb)
         strcpy(var_break->var_name, vd->var_name);
         break_exit_idx--;
 
-        int i, dangling = 1;
-        for (i = 0; i < MAX_BB_PRED; i++)
+        int dangling = 1;
+        for (int i = 0; i < MAX_BB_PRED; i++)
             if (switch_end->prev[i].bb)
                 dangling = 0;
 
@@ -2543,8 +2542,7 @@ basic_block_t *read_body_statement(block_t *parent, basic_block_t *bb)
         var_start->init_val = ph1_ir_idx - 1;
         lex_expect(T_semicolon);
 
-        int i;
-        for (i = 0; i < MAX_BB_PRED; i++) {
+        for (int i = 0; i < MAX_BB_PRED; i++) {
             if (cond_->prev[i].bb) {
                 bb_connect(cond_, bb, THEN);
                 bb_connect(cond_, do_while_end, ELSE);
@@ -2698,8 +2696,7 @@ void read_func_body(func_t *fdef, fn_t *fn)
     fn->bbs = bb_create(blk);
     fn->exit = bb_create(blk);
 
-    int i;
-    for (i = 0; i < fdef->num_params; i++) {
+    for (int i = 0; i < fdef->num_params; i++) {
         /* arguments */
         add_symbol(fn->bbs, &fdef->param_defs[i]);
         fdef->param_defs[i].base = &fdef->param_defs[i];

--- a/src/peephole.c
+++ b/src/peephole.c
@@ -53,12 +53,10 @@ void insn_fusion(ph2_ir_t *ph2_ir)
 /* FIXME: release detached basic blocks */
 void peephole()
 {
-    fn_t *fn;
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
-        basic_block_t *bb;
-        for (bb = fn->bbs; bb; bb = bb->rpo_next) {
-            ph2_ir_t *ph2_ir;
-            for (ph2_ir = bb->ph2_ir_list.head; ph2_ir; ph2_ir = ph2_ir->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
+        for (basic_block_t *bb = fn->bbs; bb; bb = bb->rpo_next) {
+            for (ph2_ir_t *ph2_ir = bb->ph2_ir_list.head; ph2_ir;
+                 ph2_ir = ph2_ir->next) {
                 ph2_ir_t *next = ph2_ir->next;
                 if (!next)
                     continue;

--- a/src/reg-alloc.c
+++ b/src/reg-alloc.c
@@ -14,8 +14,7 @@
 
 int check_live_out(basic_block_t *bb, var_t *var)
 {
-    int i;
-    for (i = 0; i < bb->live_out_idx; i++)
+    for (int i = 0; i < bb->live_out_idx; i++)
         if (bb->live_out[i] == var)
             return 1;
     return 0;
@@ -23,8 +22,7 @@ int check_live_out(basic_block_t *bb, var_t *var)
 
 void refresh(basic_block_t *bb, insn_t *insn)
 {
-    int i;
-    for (i = 0; i < REG_CNT; i++) {
+    for (int i = 0; i < REG_CNT; i++) {
         if (!REGS[i].var)
             continue;
         if (check_live_out(bb, REGS[i].var))
@@ -76,8 +74,7 @@ void spill_var(basic_block_t *bb, var_t *var, int idx)
 /* Return the index of register for given variable. Otherwise, return -1. */
 int find_in_regs(var_t *var)
 {
-    int i;
-    for (i = 0; i < REG_CNT; i++) {
+    for (int i = 0; i < REG_CNT; i++) {
         if (REGS[i].var == var)
             return i;
     }
@@ -183,8 +180,7 @@ int prepare_dest(basic_block_t *bb, var_t *var, int operand_0, int operand_1)
 
 void spill_alive(basic_block_t *bb, insn_t *insn)
 {
-    int i;
-    for (i = 0; i < REG_CNT; i++) {
+    for (int i = 0; i < REG_CNT; i++) {
         if (!REGS[i].var)
             continue;
         if (check_live_out(bb, REGS[i].var)) {
@@ -200,8 +196,7 @@ void spill_alive(basic_block_t *bb, insn_t *insn)
 
 void spill_live_out(basic_block_t *bb)
 {
-    int i;
-    for (i = 0; i < REG_CNT; i++) {
+    for (int i = 0; i < REG_CNT; i++) {
         if (!REGS[i].var)
             continue;
         if (!check_live_out(bb, REGS[i].var)) {
@@ -230,8 +225,7 @@ void extend_liveness(basic_block_t *bb, insn_t *insn, var_t *var, int offset)
 void reg_alloc()
 {
     /* TODO: .bss and .data section */
-    insn_t *global_insn;
-    for (global_insn = GLOBAL_FUNC.fn->bbs->insn_list.head; global_insn;
+    for (insn_t *global_insn = GLOBAL_FUNC.fn->bbs->insn_list.head; global_insn;
          global_insn = global_insn->next) {
         ph2_ir_t *ir;
         int dest, src0;
@@ -293,26 +287,24 @@ void reg_alloc()
         }
     }
 
-    fn_t *fn;
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         fn->visited++;
 
         if (!strcmp(fn->func->return_def.var_name, "main"))
             MAIN_BB = fn->bbs;
 
-        int i;
-        for (i = 0; i < REG_CNT; i++)
+        for (int i = 0; i < REG_CNT; i++)
             REGS[i].var = NULL;
 
         /* set arguments available */
-        for (i = 0; i < fn->func->num_params; i++) {
+        for (int i = 0; i < fn->func->num_params; i++) {
             REGS[i].var = fn->func->param_defs[i].subscripts[0];
             REGS[i].polluted = 1;
         }
 
         /* variadic function implementation */
         if (fn->func->va_args) {
-            for (i = 0; i < MAX_PARAMS; i++) {
+            for (int i = 0; i < MAX_PARAMS; i++) {
                 ph2_ir_t *ir = bb_add_ph2_ir(fn->bbs, OP_store);
 
                 if (i < fn->func->num_params)
@@ -325,14 +317,12 @@ void reg_alloc()
             }
         }
 
-        basic_block_t *bb;
-        for (bb = fn->bbs; bb; bb = bb->rpo_next) {
+        for (basic_block_t *bb = fn->bbs; bb; bb = bb->rpo_next) {
             int is_pushing_args = 0, args = 0;
 
             bb->visited++;
 
-            insn_t *insn;
-            for (insn = bb->insn_list.head; insn; insn = insn->next) {
+            for (insn_t *insn = bb->insn_list.head; insn; insn = insn->next) {
                 func_t *func;
                 ph2_ir_t *ir;
                 int dest, src0, src1;
@@ -406,8 +396,7 @@ void reg_alloc()
                         insn->rs1->offset = bb->belong_to->func->stack_size;
                         bb->belong_to->func->stack_size += 4;
 
-                        int i;
-                        for (i = 0; i < REG_CNT; i++)
+                        for (int i = 0; i < REG_CNT; i++)
                             if (REGS[i].var == insn->rs1) {
                                 ir = bb_add_ph2_ir(bb, OP_store);
                                 ir->src0 = i;
@@ -615,7 +604,7 @@ void reg_alloc()
         }
 
         /* handle implicit return */
-        for (i = 0; i < MAX_BB_PRED; i++) {
+        for (int i = 0; i < MAX_BB_PRED; i++) {
             basic_block_t *bb = fn->exit->prev[i].bb;
             if (!bb)
                 continue;
@@ -635,15 +624,12 @@ void reg_alloc()
 
 void dump_ph2_ir()
 {
-    ph2_ir_t *ph2_ir;
-    int i, rd, rs1, rs2;
+    for (int i = 0; i < ph2_ir_idx; i++) {
+        ph2_ir_t *ph2_ir = &PH2_IR[i];
 
-    for (i = 0; i < ph2_ir_idx; i++) {
-        ph2_ir = &PH2_IR[i];
-
-        rd = ph2_ir->dest + 48;
-        rs1 = ph2_ir->src0 + 48;
-        rs2 = ph2_ir->src1 + 48;
+        int rd = ph2_ir->dest + 48;
+        int rs1 = ph2_ir->src0 + 48;
+        int rs2 = ph2_ir->src1 + 48;
 
         switch (ph2_ir->op) {
         case OP_define:

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -97,32 +97,29 @@ void cfg_flatten()
     elf_offset = 84; /* offset of start + exit + syscall in codegen */
     GLOBAL_FUNC.fn->bbs->elf_offset = elf_offset;
 
-    ph2_ir_t *ph2_ir;
-    for (ph2_ir = GLOBAL_FUNC.fn->bbs->ph2_ir_list.head; ph2_ir;
+    for (ph2_ir_t *ph2_ir = GLOBAL_FUNC.fn->bbs->ph2_ir_list.head; ph2_ir;
          ph2_ir = ph2_ir->next)
         update_elf_offset(ph2_ir);
 
     /* prepare `argc` and `argv`, then proceed to `main` function */
     elf_offset += 24;
 
-    fn_t *fn;
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         ph2_ir_t *flatten_ir;
 
         /* reserve stack */
         flatten_ir = add_ph2_ir(OP_define);
         flatten_ir->src0 = fn->func->stack_size;
 
-        basic_block_t *bb;
-        for (bb = fn->bbs; bb; bb = bb->rpo_next) {
+        for (basic_block_t *bb = fn->bbs; bb; bb = bb->rpo_next) {
             bb->elf_offset = elf_offset;
 
             if (bb == fn->bbs)
                 /* save ra, sp */
                 elf_offset += 16;
 
-            ph2_ir_t *insn;
-            for (insn = bb->ph2_ir_list.head; insn; insn = insn->next) {
+            for (ph2_ir_t *insn = bb->ph2_ir_list.head; insn;
+                 insn = insn->next) {
                 flatten_ir = add_ph2_ir(OP_generic);
                 memcpy(flatten_ir, insn, sizeof(ph2_ir_t));
 
@@ -399,8 +396,7 @@ void code_generate()
     emit(__addi(__a1, __t0, 4));
     emit(__jal(__zero, MAIN_BB->elf_offset - elf_code_idx));
 
-    int i;
-    for (i = 0; i < ph2_ir_idx; i++) {
+    for (int i = 0; i < ph2_ir_idx; i++) {
         ph2_ir = &PH2_IR[i];
         emit_ph2_ir(ph2_ir);
     }

--- a/src/ssa.c
+++ b/src/ssa.c
@@ -48,8 +48,7 @@ void bb_backward_traversal(bb_traversal_args_t *args)
     if (args->preorder_cb)
         args->preorder_cb(args->fn, args->bb);
 
-    int i;
-    for (i = 0; i < MAX_BB_PRED; i++) {
+    for (int i = 0; i < MAX_BB_PRED; i++) {
         if (!args->bb->prev[i].bb)
             continue;
         if (args->bb->prev[i].bb->visited < args->fn->visited) {
@@ -101,9 +100,8 @@ void bb_build_rpo(fn_t *fn, basic_block_t *bb)
 
 void build_rpo()
 {
-    fn_t *fn;
     bb_traversal_args_t *args = calloc(1, sizeof(bb_traversal_args_t));
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         args->fn = fn;
         args->bb = fn->bbs;
 
@@ -146,8 +144,7 @@ basic_block_t *intersect(basic_block_t *i, basic_block_t *j)
  */
 void build_idom()
 {
-    fn_t *fn;
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         int changed;
 
         fn->bbs->idom = fn->bbs;
@@ -155,12 +152,10 @@ void build_idom()
         do {
             changed = 0;
 
-            basic_block_t *bb;
-            for (bb = fn->bbs->rpo_next; bb; bb = bb->rpo_next) {
+            for (basic_block_t *bb = fn->bbs->rpo_next; bb; bb = bb->rpo_next) {
                 /* pick one predecessor */
                 basic_block_t *pred;
-                int i;
-                for (i = 0; i < MAX_BB_PRED; i++) {
+                for (int i = 0; i < MAX_BB_PRED; i++) {
                     if (!bb->prev[i].bb)
                         continue;
                     if (!bb->prev[i].bb->idom)
@@ -169,7 +164,7 @@ void build_idom()
                     break;
                 }
 
-                for (i = 0; i < MAX_BB_PRED; i++) {
+                for (int i = 0; i < MAX_BB_PRED; i++) {
                     if (!bb->prev[i].bb)
                         continue;
                     if (bb->prev[i].bb == pred)
@@ -221,9 +216,8 @@ void bb_build_dom(fn_t *fn, basic_block_t *bb)
 
 void build_dom()
 {
-    fn_t *fn;
     bb_traversal_args_t *args = calloc(1, sizeof(bb_traversal_args_t));
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         args->fn = fn;
         args->bb = fn->bbs;
 
@@ -238,25 +232,24 @@ void bb_build_df(fn_t *fn, basic_block_t *bb)
 {
     UNUSED(fn);
 
-    int i, cnt = 0;
-    for (i = 0; i < MAX_BB_PRED; i++)
+    int cnt = 0;
+    for (int i = 0; i < MAX_BB_PRED; i++)
         if (bb->prev[i].bb)
             cnt++;
 
     if (cnt > 1)
-        for (i = 0; i < MAX_BB_PRED; i++)
+        for (int i = 0; i < MAX_BB_PRED; i++)
             if (bb->prev[i].bb) {
-                basic_block_t *curr;
-                for (curr = bb->prev[i].bb; curr != bb->idom; curr = curr->idom)
+                for (basic_block_t *curr = bb->prev[i].bb; curr != bb->idom;
+                     curr = curr->idom)
                     curr->DF[curr->df_idx++] = bb;
             }
 }
 
 void build_df()
 {
-    fn_t *fn;
     bb_traversal_args_t *args = calloc(1, sizeof(bb_traversal_args_t));
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         args->fn = fn;
         args->bb = fn->bbs;
 
@@ -269,8 +262,7 @@ void build_df()
 
 int var_check_killed(var_t *var, basic_block_t *bb)
 {
-    int i;
-    for (i = 0; i < bb->live_kill_idx; i++) {
+    for (int i = 0; i < bb->live_kill_idx; i++) {
         if (bb->live_kill[i] == var)
             return 1;
     }
@@ -279,8 +271,8 @@ int var_check_killed(var_t *var, basic_block_t *bb)
 
 void bb_add_killed_var(basic_block_t *bb, var_t *var)
 {
-    int i, found = 0;
-    for (i = 0; i < bb->live_kill_idx; i++) {
+    int found = 0;
+    for (int i = 0; i < bb->live_kill_idx; i++) {
         if (bb->live_kill[i] == var) {
             found = 1;
             break;
@@ -348,8 +340,7 @@ void bb_solve_globals(fn_t *fn, basic_block_t *bb)
 {
     UNUSED(fn);
 
-    insn_t *insn;
-    for (insn = bb->insn_list.head; insn; insn = insn->next) {
+    for (insn_t *insn = bb->insn_list.head; insn; insn = insn->next) {
         if (insn->rs1)
             if (!var_check_killed(insn->rs1, bb))
                 fn_add_global(bb->belong_to, insn->rs1);
@@ -365,9 +356,8 @@ void bb_solve_globals(fn_t *fn, basic_block_t *bb)
 
 void solve_globals()
 {
-    fn_t *fn;
     bb_traversal_args_t *args = calloc(1, sizeof(bb_traversal_args_t));
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         args->fn = fn;
         args->bb = fn->bbs;
 
@@ -383,8 +373,7 @@ int var_check_in_scope(var_t *var, block_t *block)
     func_t *fn = block->func;
 
     while (block) {
-        int i;
-        for (i = 0; i < block->next_local; i++) {
+        for (int i = 0; i < block->next_local; i++) {
             var_t *locals = block->locals;
             if (var == &locals[i])
                 return 1;
@@ -392,8 +381,7 @@ int var_check_in_scope(var_t *var, block_t *block)
         block = block->parent;
     }
 
-    int i;
-    for (i = 0; i < fn->num_params; i++) {
+    for (int i = 0; i < fn->num_params; i++) {
         if (&fn->param_defs[i] == var)
             return 1;
     }
@@ -403,9 +391,8 @@ int var_check_in_scope(var_t *var, block_t *block)
 
 int insert_phi_insn(basic_block_t *bb, var_t *var)
 {
-    insn_t *insn;
     int found = 0;
-    for (insn = bb->insn_list.head; insn; insn = insn->next) {
+    for (insn_t *insn = bb->insn_list.head; insn; insn = insn->next) {
         if ((insn->opcode == OP_phi) && (insn->rd == var)) {
             found = 1;
             break;
@@ -432,31 +419,26 @@ int insert_phi_insn(basic_block_t *bb, var_t *var)
 
 void solve_phi_insertion()
 {
-    fn_t *fn;
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
-        symbol_t *sym;
-        for (sym = fn->global_sym_list.head; sym; sym = sym->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
+        for (symbol_t *sym = fn->global_sym_list.head; sym; sym = sym->next) {
             var_t *var = sym->var;
 
             basic_block_t *work_list[64];
             int work_list_idx = 0;
 
-            ref_block_t *ref;
-            for (ref = var->ref_block_list.head; ref; ref = ref->next)
+            for (ref_block_t *ref = var->ref_block_list.head; ref;
+                 ref = ref->next)
                 work_list[work_list_idx++] = ref->bb;
 
-            int i;
-            for (i = 0; i < work_list_idx; i++) {
+            for (int i = 0; i < work_list_idx; i++) {
                 basic_block_t *bb = work_list[i];
-                int j;
-                for (j = 0; j < bb->df_idx; j++) {
+                for (int j = 0; j < bb->df_idx; j++) {
                     basic_block_t *df = bb->DF[j];
                     if (!var_check_in_scope(var, df->scope))
                         continue;
 
                     int is_decl = 0;
-                    symbol_t *s;
-                    for (s = df->symbol_list.head; s; s = s->next)
+                    for (symbol_t *s = df->symbol_list.head; s; s = s->next)
                         if (s->var == var) {
                             is_decl = 1;
                             break;
@@ -472,7 +454,7 @@ void solve_phi_insertion()
                         continue;
 
                     if (insert_phi_insn(df, var)) {
-                        int l, found = 0;
+                        int found = 0;
 
                         /* Restrict phi insertion of ternary operation.
                          *
@@ -483,7 +465,7 @@ void solve_phi_insertion()
                         if (var->is_ternary_ret)
                             continue;
 
-                        for (l = 0; l < work_list_idx; l++)
+                        for (int l = 0; l < work_list_idx; l++)
                             if (work_list[l] == df) {
                                 found = 1;
                                 break;
@@ -523,8 +505,7 @@ var_t *get_stack_top_subscript_var(var_t *var)
         error("Index is less than 1");
 
     int sub = var->base->rename.stack[var->base->rename.stack_idx - 1];
-    int i;
-    for (i = 0; i < var->base->subscripts_idx; i++) {
+    for (int i = 0; i < var->base->subscripts_idx; i++) {
         if (var->base->subscripts[i]->subscript == sub)
             return var->base->subscripts[i];
     }
@@ -567,8 +548,7 @@ void append_phi_operand(insn_t *insn, var_t *var, basic_block_t *bb_from)
 
 void bb_solve_phi_params(basic_block_t *bb)
 {
-    insn_t *insn;
-    for (insn = bb->insn_list.head; insn; insn = insn->next) {
+    for (insn_t *insn = bb->insn_list.head; insn; insn = insn->next) {
         if (insn->opcode == OP_phi)
             new_name(bb->scope, &insn->rd);
         else {
@@ -583,31 +563,30 @@ void bb_solve_phi_params(basic_block_t *bb)
     }
 
     if (bb->next) {
-        for (insn = bb->next->insn_list.head; insn; insn = insn->next)
+        for (insn_t *insn = bb->next->insn_list.head; insn; insn = insn->next)
             if (insn->opcode == OP_phi)
                 append_phi_operand(insn, insn->rd, bb);
     }
 
     if (bb->then_) {
-        for (insn = bb->then_->insn_list.head; insn; insn = insn->next)
+        for (insn_t *insn = bb->then_->insn_list.head; insn; insn = insn->next)
             if (insn->opcode == OP_phi)
                 append_phi_operand(insn, insn->rd, bb);
     }
 
     if (bb->else_) {
-        for (insn = bb->else_->insn_list.head; insn; insn = insn->next)
+        for (insn_t *insn = bb->else_->insn_list.head; insn; insn = insn->next)
             if (insn->opcode == OP_phi)
                 append_phi_operand(insn, insn->rd, bb);
     }
 
-    int i;
-    for (i = 0; i < MAX_BB_DOM_SUCC; i++) {
+    for (int i = 0; i < MAX_BB_DOM_SUCC; i++) {
         if (!bb->dom_next[i])
             break;
         bb_solve_phi_params(bb->dom_next[i]);
     }
 
-    for (insn = bb->insn_list.head; insn; insn = insn->next) {
+    for (insn_t *insn = bb->insn_list.head; insn; insn = insn->next) {
         if (insn->opcode == OP_phi)
             pop_name(insn->rd);
         else if (insn->rd)
@@ -617,10 +596,8 @@ void bb_solve_phi_params(basic_block_t *bb)
 
 void solve_phi_params()
 {
-    fn_t *fn;
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
-        int i;
-        for (i = 0; i < fn->func->num_params; i++) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
+        for (int i = 0; i < fn->func->num_params; i++) {
             /* FIXME: Rename arguments directly, might be not good here. */
             var_t *var = require_var(fn->bbs->scope);
             var_t *base = &fn->func->param_defs[i];
@@ -675,8 +652,8 @@ void bb_unwind_phi(fn_t *fn, basic_block_t *bb)
         if (insn->opcode != OP_phi)
             break;
 
-        phi_operand_t *operand;
-        for (operand = insn->phi_ops; operand; operand = operand->next)
+        for (phi_operand_t *operand = insn->phi_ops; operand;
+             operand = operand->next)
             append_unwound_phi_insn(operand->from, insn->rd, operand->var);
         /* TODO: Release dangling phi instruction */
     }
@@ -688,9 +665,8 @@ void bb_unwind_phi(fn_t *fn, basic_block_t *bb)
 
 void unwind_phi()
 {
-    fn_t *fn;
     bb_traversal_args_t *args = calloc(1, sizeof(bb_traversal_args_t));
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         args->fn = fn;
         args->bb = fn->bbs;
 
@@ -833,8 +809,7 @@ void bb_dump(FILE *fd, fn_t *fn, basic_block_t *bb)
                     insn->phi_ops->var->var_name,
                     insn->phi_ops->var->subscript);
 
-            phi_operand_t *op;
-            for (op = insn->phi_ops->next; op; op = op->next) {
+            for (phi_operand_t *op = insn->phi_ops->next; op; op = op->next) {
                 fprintf(fd, ", %s<SUB>%d</SUB>", op->var->var_name,
                         op->var->subscript);
             }
@@ -972,8 +947,7 @@ void bb_dump(FILE *fd, fn_t *fn, basic_block_t *bb)
         bb_dump_connection(fd, bb, bb->else_, ELSE);
     }
 
-    int i;
-    for (i = 0; i < MAX_BB_PRED; i++)
+    for (int i = 0; i < MAX_BB_PRED; i++)
         if (bb->prev[i].bb)
             bb_dump_connection(fd, bb->prev[i].bb, bb, bb->prev[i].type);
 }
@@ -981,11 +955,10 @@ void bb_dump(FILE *fd, fn_t *fn, basic_block_t *bb)
 void dump_cfg(char name[])
 {
     FILE *fd = fopen(name, "w");
-    fn_t *fn;
 
     fprintf(fd, "strict digraph CFG {\n");
     fprintf(fd, "node [shape=box]\n");
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         fn->visited++;
         fprintf(fd, "subgraph cluster_%p {\n", fn);
         fprintf(fd, "label=\"%p\"\n", fn);
@@ -999,8 +972,7 @@ void dump_cfg(char name[])
 void dom_dump(FILE *fd, basic_block_t *bb)
 {
     fprintf(fd, "\"%p\"\n", bb);
-    int i;
-    for (i = 0; i < MAX_BB_DOM_SUCC; i++) {
+    for (int i = 0; i < MAX_BB_DOM_SUCC; i++) {
         if (!bb->dom_next[i])
             break;
         dom_dump(fd, bb->dom_next[i]);
@@ -1011,12 +983,11 @@ void dom_dump(FILE *fd, basic_block_t *bb)
 void dump_dom(char name[])
 {
     FILE *fd = fopen(name, "w");
-    fn_t *fn;
 
     fprintf(fd, "strict digraph DOM {\n");
     fprintf(fd, "node [shape=box]\n");
     fprintf(fd, "splines=polyline\n");
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         fprintf(fd, "subgraph cluster_%p {\n", fn);
         fprintf(fd, "label=\"%p\"\n", fn);
         dom_dump(fd, fn->bbs);
@@ -1070,9 +1041,8 @@ int cse(insn_t *insn, basic_block_t *bb)
     if (base->is_global || idx->is_global)
         return 0;
 
-    basic_block_t *b;
     insn_t *i = prev;
-    for (b = bb;; b = b->idom) {
+    for (basic_block_t *b = bb;; b = b->idom) {
         if (!i)
             i = b->insn_list.tail;
 
@@ -1194,15 +1164,12 @@ int const_folding(insn_t *insn)
 
 void optimize()
 {
-    fn_t *fn;
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         /* basic block level (control flow) optimizations */
 
-        basic_block_t *bb;
-        for (bb = fn->bbs; bb; bb = bb->rpo_next) {
+        for (basic_block_t *bb = fn->bbs; bb; bb = bb->rpo_next) {
             /* instruction level optimizations */
-            insn_t *insn;
-            for (insn = bb->insn_list.head; insn; insn = insn->next) {
+            for (insn_t *insn = bb->insn_list.head; insn; insn = insn->next) {
                 if (cse(insn, bb))
                     continue;
                 if (const_folding(insn))
@@ -1247,9 +1214,8 @@ void bb_build_reversed_rpo(fn_t *fn, basic_block_t *bb)
 
 void build_reversed_rpo()
 {
-    fn_t *fn;
     bb_traversal_args_t *args = calloc(1, sizeof(bb_traversal_args_t));
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         fn->bb_cnt = 0;
         args->fn = fn;
         args->bb = fn->exit;
@@ -1280,8 +1246,7 @@ void add_live_gen(basic_block_t *bb, var_t *var)
     if (var->is_global)
         return;
 
-    int i;
-    for (i = 0; i < bb->live_gen_idx; i++)
+    for (int i = 0; i < bb->live_gen_idx; i++)
         if (bb->live_gen[i] == var)
             return;
     bb->live_gen[bb->live_gen_idx++] = var;
@@ -1298,8 +1263,7 @@ void bb_solve_locals(fn_t *fn, basic_block_t *bb)
     UNUSED(fn);
 
     int i = 0;
-    insn_t *insn;
-    for (insn = bb->insn_list.head; insn; insn = insn->next) {
+    for (insn_t *insn = bb->insn_list.head; insn; insn = insn->next) {
         insn->idx = i++;
 
         if (insn->rs1) {
@@ -1320,8 +1284,7 @@ void bb_solve_locals(fn_t *fn, basic_block_t *bb)
 
 void add_live_in(basic_block_t *bb, var_t *var)
 {
-    int i;
-    for (i = 0; i < bb->live_in_idx; i++)
+    for (int i = 0; i < bb->live_in_idx; i++)
         if (bb->live_in[i] == var)
             return;
     bb->live_in[bb->live_in_idx++] = var;
@@ -1331,22 +1294,20 @@ void compute_live_in(basic_block_t *bb)
 {
     bb->live_in_idx = 0;
 
-    int i;
-    for (i = 0; i < bb->live_out_idx; i++) {
+    for (int i = 0; i < bb->live_out_idx; i++) {
         if (var_check_killed(bb->live_out[i], bb))
             continue;
         add_live_in(bb, bb->live_out[i]);
     }
-    for (i = 0; i < bb->live_gen_idx; i++)
+    for (int i = 0; i < bb->live_gen_idx; i++)
         add_live_in(bb, bb->live_gen[i]);
 }
 
 int merge_live_in(var_t *live_out[], int live_out_idx, basic_block_t *bb)
 {
-    int i;
-    for (i = 0; i < bb->live_in_idx; i++) {
-        int j, found = 0;
-        for (j = 0; j < live_out_idx; j++)
+    for (int i = 0; i < bb->live_in_idx; i++) {
+        int found = 0;
+        for (int j = 0; j < live_out_idx; j++)
             if (live_out[j] == bb->live_in[i]) {
                 found = 1;
                 break;
@@ -1381,10 +1342,9 @@ int recompute_live_out(basic_block_t *bb)
         return 1;
     }
 
-    int i;
-    for (i = 0; i < live_out_idx; i++) {
-        int j, same = 0;
-        for (j = 0; j < bb->live_out_idx; j++)
+    for (int i = 0; i < live_out_idx; i++) {
+        int same = 0;
+        for (int j = 0; j < bb->live_out_idx; j++)
             if (live_out[i] == bb->live_out[j]) {
                 same = 1;
                 break;
@@ -1402,9 +1362,8 @@ void liveness_analysis()
 {
     build_reversed_rpo();
 
-    fn_t *fn;
     bb_traversal_args_t *args = calloc(1, sizeof(bb_traversal_args_t));
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         args->fn = fn;
         args->bb = fn->bbs;
 
@@ -1412,8 +1371,7 @@ void liveness_analysis()
         args->preorder_cb = bb_reset_live_kill_idx;
         bb_forward_traversal(args);
 
-        int i;
-        for (i = 0; i < fn->func->num_params; i++)
+        for (int i = 0; i < fn->func->num_params; i++)
             bb_add_killed_var(fn->bbs, fn->func->param_defs[i].subscripts[0]);
 
         fn->visited++;
@@ -1422,7 +1380,7 @@ void liveness_analysis()
     }
     free(args);
 
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         basic_block_t *bb = fn->exit;
         int changed;
         do {
@@ -1446,8 +1404,7 @@ void bb_release(fn_t *fn, basic_block_t *bb)
     }
 
     /* disconnect all predecessors */
-    int i;
-    for (i = 0; i < MAX_BB_PRED; i++) {
+    for (int i = 0; i < MAX_BB_PRED; i++) {
         if (!bb->prev[i].bb)
             continue;
         switch (bb->prev[i].type) {
@@ -1471,9 +1428,8 @@ void bb_release(fn_t *fn, basic_block_t *bb)
 
 void ssa_release()
 {
-    fn_t *fn;
     bb_traversal_args_t *args = calloc(1, sizeof(bb_traversal_args_t));
-    for (fn = FUNC_LIST.head; fn; fn = fn->next) {
+    for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         args->fn = fn;
         args->bb = fn->bbs;
 


### PR DESCRIPTION
In C99, it is possible to declare variables precisely where they are needed, a feature also present in C++. Variables can also be declared within the control structure of a for loop, a feature introduced in C99:

    for (int x = 0; x < 10; x++) {  /* This is permitted starting with C99 */
        ...
    }

Line of code count via 'cloc' command:

- [ ] before
```
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
SUM:                            13           1049            584           7552
-------------------------------------------------------------------------------
```

- [ ] after
```
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
SUM:                            13           1046            584           7458
-------------------------------------------------------------------------------
```