### PR TITLE
Implement macros defined in `<stdbool.h>`

### DIFF
--- a/lib/c.c
+++ b/lib/c.c
@@ -9,6 +9,10 @@
 
 #define NULL 0
 
+#define bool _Bool
+#define true 1
+#define false 0
+
 #if defined(__arm__)
 #define __syscall_exit 1
 #define __syscall_read 3

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -83,16 +83,16 @@ typedef enum {
 char token_str[MAX_TOKEN_LEN];
 token_t next_token;
 char next_char;
-int skip_newline = 1;
+bool skip_newline = true;
 
-int preproc_match;
+bool preproc_match;
 
 /* Point to the first character after where the macro has been called. It is
  * needed when returning from the macro body.
  */
 int macro_return_idx;
 
-int is_whitespace(char c)
+bool is_whitespace(char c)
 {
     return c == ' ' || c == '\t';
 }
@@ -100,53 +100,53 @@ int is_whitespace(char c)
 char peek_char(int offset);
 
 /* is it backslash-newline? */
-int is_linebreak(char c)
+bool is_linebreak(char c)
 {
     return c == '\\' && peek_char(1) == '\n';
 }
 
-int is_newline(char c)
+bool is_newline(char c)
 {
     return c == '\r' || c == '\n';
 }
 
 /* is it alphabet, number or '_'? */
-int is_alnum(char c)
+bool is_alnum(char c)
 {
     return ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
             (c >= '0' && c <= '9') || (c == '_'));
 }
 
-int is_digit(char c)
+bool is_digit(char c)
 {
     return c >= '0' && c <= '9';
 }
 
-int is_hex(char c)
+bool is_hex(char c)
 {
     return ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || c == 'x' ||
             (c >= 'A' && c <= 'F'));
 }
 
-int is_numeric(char buffer[])
+bool is_numeric(char buffer[])
 {
     int hex = 0, size = strlen(buffer);
 
     if (size > 2)
-        hex = (buffer[0] == '0' && buffer[1] == 'x') ? 1 : 0;
+        hex = buffer[0] == '0' && buffer[1] == 'x';
 
     for (int i = 0; i < size; i++) {
-        if (hex && (is_hex(buffer[i]) == 0))
-            return 0;
-        if (!hex && (is_digit(buffer[i]) == 0))
-            return 0;
+        if (hex && !is_hex(buffer[i]))
+            return false;
+        if (!hex && !is_digit(buffer[i]))
+            return false;
     }
-    return 1;
+    return true;
 }
 
 void skip_whitespace()
 {
-    while (1) {
+    while (true) {
         if (is_linebreak(next_char)) {
             source_idx += 2;
             next_char = SOURCE[source_idx];
@@ -161,10 +161,10 @@ void skip_whitespace()
     }
 }
 
-char read_char(int is_skip_space)
+char read_char(bool is_skip_space)
 {
     next_char = SOURCE[++source_idx];
-    if (is_skip_space == 1)
+    if (is_skip_space)
         skip_whitespace();
     return next_char;
 }
@@ -177,7 +177,7 @@ char peek_char(int offset)
 /* Lex next token and returns its token type. Parameter 'aliasing' is used for
  * disable preprocessor aliasing on identifier tokens.
  */
-token_t lex_token_internal(int aliasing)
+token_t lex_token_internal(bool aliasing)
 {
     token_str[0] = 0;
 
@@ -187,7 +187,7 @@ token_t lex_token_internal(int aliasing)
 
         do {
             token_str[i++] = next_char;
-        } while (is_alnum(read_char(0)));
+        } while (is_alnum(read_char(false)));
         token_str[i] = 0;
         skip_whitespace();
 
@@ -214,15 +214,15 @@ token_t lex_token_internal(int aliasing)
 
     /* C-style comments */
     if (next_char == '/') {
-        read_char(0);
+        read_char(false);
         if (next_char == '*') {
             /* in a comment, skip until end */
             do {
-                read_char(0);
+                read_char(false);
                 if (next_char == '*') {
-                    read_char(0);
+                    read_char(false);
                     if (next_char == '/') {
-                        read_char(1);
+                        read_char(true);
                         return lex_token_internal(aliasing);
                     }
                 }
@@ -230,7 +230,7 @@ token_t lex_token_internal(int aliasing)
         } else {
             /* single '/', predict divide */
             if (next_char == ' ')
-                read_char(1);
+                read_char(true);
             return T_divide;
         }
         /* TODO: check invalid cases */
@@ -241,52 +241,52 @@ token_t lex_token_internal(int aliasing)
         int i = 0;
         do {
             token_str[i++] = next_char;
-        } while (is_hex(read_char(0)));
+        } while (is_hex(read_char(false)));
         token_str[i] = 0;
         skip_whitespace();
         return T_numeric;
     }
     if (next_char == '(') {
-        read_char(1);
+        read_char(true);
         return T_open_bracket;
     }
     if (next_char == ')') {
-        read_char(1);
+        read_char(true);
         return T_close_bracket;
     }
     if (next_char == '{') {
-        read_char(1);
+        read_char(true);
         return T_open_curly;
     }
     if (next_char == '}') {
-        read_char(1);
+        read_char(true);
         return T_close_curly;
     }
     if (next_char == '[') {
-        read_char(1);
+        read_char(true);
         return T_open_square;
     }
     if (next_char == ']') {
-        read_char(1);
+        read_char(true);
         return T_close_square;
     }
     if (next_char == ',') {
-        read_char(1);
+        read_char(true);
         return T_comma;
     }
     if (next_char == '^') {
-        read_char(1);
+        read_char(true);
         return T_bit_xor;
     }
     if (next_char == '~') {
-        read_char(1);
+        read_char(true);
         return T_bit_not;
     }
     if (next_char == '"') {
         int i = 0;
         int special = 0;
 
-        while ((read_char(0) != '"') || special) {
+        while ((read_char(false) != '"') || special) {
             if ((i > 0) && (token_str[i - 1] == '\\')) {
                 if (next_char == 'n')
                     token_str[i - 1] = '\n';
@@ -311,13 +311,13 @@ token_t lex_token_internal(int aliasing)
                 special = 0;
         }
         token_str[i] = 0;
-        read_char(1);
+        read_char(true);
         return T_string;
     }
     if (next_char == '\'') {
-        read_char(0);
+        read_char(false);
         if (next_char == '\\') {
-            read_char(0);
+            read_char(false);
             if (next_char == 'n')
                 token_str[0] = '\n';
             else if (next_char == 'r')
@@ -336,86 +336,86 @@ token_t lex_token_internal(int aliasing)
             token_str[0] = next_char;
         }
         token_str[1] = 0;
-        if (read_char(0) != '\'')
+        if (read_char(true) != '\'')
             abort();
-        read_char(1);
+        read_char(true);
         return T_char;
     }
     if (next_char == '*') {
-        read_char(1);
+        read_char(true);
         return T_asterisk;
     }
     if (next_char == '&') {
-        read_char(0);
+        read_char(false);
         if (next_char == '&') {
-            read_char(1);
+            read_char(true);
             return T_log_and;
         };
         if (next_char == '=') {
-            read_char(1);
+            read_char(true);
             return T_andeq;
         }
         skip_whitespace();
         return T_ampersand;
     }
     if (next_char == '|') {
-        read_char(0);
+        read_char(false);
         if (next_char == '|') {
-            read_char(1);
+            read_char(true);
             return T_log_or;
         };
         if (next_char == '=') {
-            read_char(1);
+            read_char(true);
             return T_oreq;
         }
         skip_whitespace();
         return T_bit_or;
     }
     if (next_char == '<') {
-        read_char(0);
+        read_char(false);
         if (next_char == '=') {
-            read_char(1);
+            read_char(true);
             return T_le;
         };
         if (next_char == '<') {
-            read_char(1);
+            read_char(true);
             return T_lshift;
         };
         skip_whitespace();
         return T_lt;
     }
     if (next_char == '%') {
-        read_char(1);
+        read_char(true);
         return T_mod;
     }
     if (next_char == '>') {
-        read_char(0);
+        read_char(false);
         if (next_char == '=') {
-            read_char(1);
+            read_char(true);
             return T_ge;
         };
         if (next_char == '>') {
-            read_char(1);
+            read_char(true);
             return T_rshift;
         };
         skip_whitespace();
         return T_gt;
     }
     if (next_char == '!') {
-        read_char(0);
+        read_char(false);
         if (next_char == '=') {
-            read_char(1);
+            read_char(true);
             return T_noteq;
         }
         skip_whitespace();
         return T_log_not;
     }
     if (next_char == '.') {
-        read_char(0);
+        read_char(false);
         if (next_char == '.') {
-            read_char(0);
+            read_char(false);
             if (next_char == '.') {
-                read_char(1);
+                read_char(true);
                 return T_elipsis;
             }
             abort();
@@ -424,51 +424,51 @@ token_t lex_token_internal(int aliasing)
         return T_dot;
     }
     if (next_char == '-') {
-        read_char(0);
+        read_char(true);
         if (next_char == '>') {
-            read_char(1);
+            read_char(true);
             return T_arrow;
         }
         if (next_char == '-') {
-            read_char(1);
+            read_char(true);
             return T_decrement;
         }
         if (next_char == '=') {
-            read_char(1);
+            read_char(true);
             return T_minuseq;
         }
         skip_whitespace();
         return T_minus;
     }
     if (next_char == '+') {
-        read_char(0);
+        read_char(false);
         if (next_char == '+') {
-            read_char(1);
+            read_char(true);
             return T_increment;
         }
         if (next_char == '=') {
-            read_char(1);
+            read_char(true);
             return T_pluseq;
         }
         skip_whitespace();
         return T_plus;
     }
     if (next_char == ';') {
-        read_char(1);
+        read_char(true);
         return T_semicolon;
     }
     if (next_char == '?') {
-        read_char(1);
+        read_char(true);
         return T_question;
     }
     if (next_char == ':') {
-        read_char(1);
+        read_char(true);
         return T_colon;
     }
     if (next_char == '=') {
-        read_char(0);
+        read_char(false);
         if (next_char == '=') {
-            read_char(1);
+            read_char(true);
             return T_eq;
         }
         skip_whitespace();
@@ -480,7 +480,7 @@ token_t lex_token_internal(int aliasing)
         int i = 0;
         do {
             token_str[i++] = next_char;
-        } while (is_alnum(read_char(0)));
+        } while (is_alnum(read_char(false)));
         token_str[i] = 0;
         skip_whitespace();
 
@@ -535,7 +535,7 @@ token_t lex_token_internal(int aliasing)
             source_idx = macro_return_idx;
             next_char = SOURCE[source_idx];
         } else
-            next_char = read_char(1);
+            next_char = read_char(true);
         return lex_token_internal(aliasing);
     }
 
@@ -553,7 +553,7 @@ token_t lex_token_internal(int aliasing)
  */
 token_t lex_token()
 {
-    return lex_token_internal(1);
+    return lex_token_internal(true);
 }
 
 /* Skip the content. We only need the index where the macro body begins. */
@@ -562,25 +562,25 @@ void skip_macro_body()
     while (!is_newline(next_char))
         next_token = lex_token();
 
-    skip_newline = 1;
+    skip_newline = true;
     next_token = lex_token();
 }
 
 /* Accepts next token if token types are matched. */
-int lex_accept_internal(token_t token, int aliasing)
+bool lex_accept_internal(token_t token, bool aliasing)
 {
     if (next_token == token) {
         next_token = lex_token_internal(aliasing);
-        return 1;
+        return true;
     }
 
-    return 0;
+    return false;
 }
 
 /* Accepts next token if token types are matched. To disable aliasing on next
  * token, use 'lex_accept_internal'.
  */
-int lex_accept(token_t token)
+bool lex_accept(token_t token)
 {
     return lex_accept_internal(token, 1);
 }
@@ -588,21 +588,21 @@ int lex_accept(token_t token)
 /* Peeks next token and copy token's literal to value if token types are
  * matched.
  */
-int lex_peek(token_t token, char *value)
+bool lex_peek(token_t token, char *value)
 {
     if (next_token == token) {
         if (!value)
-            return 1;
+            return true;
         strcpy(value, token_str);
-        return 1;
+        return true;
     }
-    return 0;
+    return false;
 }
 
 /* Strictly match next token with given token type and copy token's literal to
  * value.
  */
-void lex_ident_internal(token_t token, char *value, int aliasing)
+void lex_ident_internal(token_t token, char *value, bool aliasing)
 {
     if (next_token != token)
         error("Unexpected token");
@@ -615,11 +615,11 @@ void lex_ident_internal(token_t token, char *value, int aliasing)
  */
 void lex_ident(token_t token, char *value)
 {
-    lex_ident_internal(token, value, 1);
+    lex_ident_internal(token, value, true);
 }
 
 /* Strictly match next token with given token type. */
-void lex_expect_internal(token_t token, int aliasing)
+void lex_expect_internal(token_t token, bool aliasing)
 {
     if (next_token != token)
         error("Unexpected token");
@@ -631,5 +631,5 @@ void lex_expect_internal(token_t token, int aliasing)
  */
 void lex_expect(token_t token)
 {
-    lex_expect_internal(token, 1);
+    lex_expect_internal(token, true);
 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -130,7 +130,8 @@ bool is_hex(char c)
 
 bool is_numeric(char buffer[])
 {
-    int hex = 0, size = strlen(buffer);
+    bool hex = false;
+    int size = strlen(buffer);
 
     if (size > 2)
         hex = buffer[0] == '0' && buffer[1] == 'x';
@@ -518,7 +519,8 @@ token_t lex_token_internal(bool aliasing)
         if (aliasing) {
             alias = find_alias(token_str);
             if (alias) {
-                token_t t = is_numeric(alias) ? T_numeric : T_string;
+                /* TODO: Need more reliable way to identify the token's type */
+                token_t t = is_numeric(alias) ? T_numeric : T_identifier;
                 strcpy(token_str, alias);
                 return t;
             }

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
 /* Define target machine */
 #include "../config"

--- a/src/main.c
+++ b/src/main.c
@@ -5,10 +5,10 @@
  * file "LICENSE" for information on usage and redistribution of this file.
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 
 /* Define target machine */
 #include "../config"

--- a/src/parser.c
+++ b/src/parser.c
@@ -240,7 +240,7 @@ int read_constant_infix_expr(int precedence)
         lhs = read_constant_expr_operand();
     }
 
-    while (1) {
+    while (true) {
         op = get_operator();
         current_precedence = get_operator_prio(op);
 
@@ -334,7 +334,7 @@ void cppd_control_flow_skip_lines()
 void check_def(char *alias)
 {
     if (find_alias(alias))
-        preproc_match = 1;
+        preproc_match = true;
 }
 
 void read_defined_macro()
@@ -352,7 +352,7 @@ void read_defined_macro()
 /* read preprocessor directive at each potential positions: e.g.,
  * global statement / body statement
  */
-int read_preproc_directive()
+bool read_preproc_directive()
 {
     char token[MAX_ID_LEN];
 
@@ -374,13 +374,13 @@ int read_preproc_directive()
             lex_expect(T_gt);
         }
 
-        return 1;
+        return true;
     }
     if (lex_accept(T_cppd_define)) {
         char alias[MAX_VAR_LEN];
         char value[MAX_VAR_LEN];
 
-        lex_ident_internal(T_identifier, alias, 0);
+        lex_ident_internal(T_identifier, alias, false);
 
         if (lex_peek(T_numeric, value)) {
             lex_expect(T_numeric);
@@ -394,7 +394,7 @@ int read_preproc_directive()
         } else if (lex_accept(T_open_bracket)) { /* function-like macro */
             macro_t *macro = add_macro(alias);
 
-            skip_newline = 0;
+            skip_newline = false;
             while (lex_peek(T_identifier, alias)) {
                 lex_expect(T_identifier);
                 strcpy(macro->param_defs[macro->num_param_defs++].var_name,
@@ -408,18 +408,18 @@ int read_preproc_directive()
             skip_macro_body();
         }
 
-        return 1;
+        return true;
     }
     if (lex_peek(T_cppd_undef, token)) {
         char alias[MAX_VAR_LEN];
 
-        lex_expect_internal(T_cppd_undef, 0);
+        lex_expect_internal(T_cppd_undef, false);
         lex_peek(T_identifier, alias);
         lex_expect(T_identifier);
 
         remove_alias(alias);
         remove_macro(alias);
-        return 1;
+        return true;
     }
     if (lex_peek(T_cppd_error, NULL)) {
         int i = 0;
@@ -427,7 +427,7 @@ int read_preproc_directive()
 
         do {
             error_diagnostic[i++] = next_char;
-        } while (read_char(0) != '\n');
+        } while (read_char(false) != '\n');
         error_diagnostic[i] = 0;
 
         error(error_diagnostic);
@@ -441,14 +441,14 @@ int read_preproc_directive()
             cppd_control_flow_skip_lines();
         }
 
-        return 1;
+        return true;
     }
     if (lex_accept(T_cppd_elif)) {
         if (preproc_match) {
             while (!lex_peek(T_cppd_endif, NULL)) {
                 next_token = lex_token();
             }
-            return 1;
+            return true;
         }
 
         preproc_match = read_constant_expr() != 0;
@@ -459,7 +459,7 @@ int read_preproc_directive()
             cppd_control_flow_skip_lines();
         }
 
-        return 1;
+        return true;
     }
     if (lex_accept(T_cppd_else)) {
         /* reach here has 2 possible cases:
@@ -468,32 +468,32 @@ int read_preproc_directive()
          */
         if (!preproc_match) {
             skip_whitespace();
-            return 1;
+            return true;
         }
 
         cppd_control_flow_skip_lines();
-        return 1;
+        return true;
     }
     if (lex_accept(T_cppd_endif)) {
-        preproc_match = 0;
+        preproc_match = false;
         skip_whitespace();
-        return 1;
+        return true;
     }
-    if (lex_accept_internal(T_cppd_ifdef, 0)) {
-        preproc_match = 0;
+    if (lex_accept_internal(T_cppd_ifdef, false)) {
+        preproc_match = false;
         lex_ident(T_identifier, token);
         check_def(token);
 
         if (preproc_match) {
             skip_whitespace();
-            return 1;
+            return true;
         }
 
         cppd_control_flow_skip_lines();
-        return 1;
+        return true;
     }
 
-    return 0;
+    return false;
 }
 
 void read_parameter_list_decl(func_t *fd, int anon);

--- a/src/parser.c
+++ b/src/parser.c
@@ -2875,6 +2875,14 @@ void parse_internal()
     type->base_type = TYPE_int;
     type->size = 4;
 
+    /* builtin type _Bool was introduced in C99 specification, it is more
+     * well-known as macro type bool, which is defined in <std_bool.h> (in
+     * shecc, it is defined in 'lib/c.c').
+     */
+    type = add_named_type("_Bool");
+    type->base_type = TYPE_char;
+    type->size = 1;
+
     add_block(NULL, NULL, NULL); /* global block */
     elf_add_symbol("", 0, 0);    /* undef symbol */
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -380,13 +380,16 @@ int read_preproc_directive()
         char alias[MAX_VAR_LEN];
         char value[MAX_VAR_LEN];
 
-        lex_ident(T_identifier, alias);
+        lex_ident_internal(T_identifier, alias, 0);
 
         if (lex_peek(T_numeric, value)) {
             lex_expect(T_numeric);
             add_alias(alias, value);
         } else if (lex_peek(T_string, value)) {
             lex_expect(T_string);
+            add_alias(alias, value);
+        } else if (lex_peek(T_identifier, value)) {
+            lex_expect(T_identifier);
             add_alias(alias, value);
         } else if (lex_accept(T_open_bracket)) { /* function-like macro */
             macro_t *macro = add_macro(alias);

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -592,4 +592,13 @@ int main()
 }
 EOF
 
+# _Bool size should be equivalent to char, which is 1 byte
+try_output 0 "1" << EOF
+int main()
+{
+    printf("%d", sizeof(bool));
+    return 0;
+}
+EOF
+
 echo OK


### PR DESCRIPTION
- Resolve #122, implements all `stdbool.h` macros in `lib/c.c`
  - This includes macro `bool`, `true` and `false`.
- Partially utilize `stdbool.h` macros in `lexer.c` and `parser.c`