### PR TITLE
Fix compilation errors when ARCH=riscv

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,9 @@ jobs:
           sudo apt-get install -q -y build-essential
           make clean config
           make check-snapshots || exit 1
-          make clean config ARCH=arm
+          make distclean config ARCH=arm
           make check || exit 1
-          make clean config ARCH=riscv
+          make distclean config ARCH=riscv
           make check || exit 1
 
   host-arm:

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -107,7 +107,7 @@ void cfg_flatten()
 
     for (fn_t *fn = FUNC_LIST.head; fn; fn = fn->next) {
         /* reserve stack */
-        ph2_ir_t *fflatten_ir = add_ph2_ir(OP_define);
+        ph2_ir_t *flatten_ir = add_ph2_ir(OP_define);
         flatten_ir->src0 = fn->func->stack_size;
 
         for (basic_block_t *bb = fn->bbs; bb; bb = bb->rpo_next) {


### PR DESCRIPTION
When ARCH=riscv, the following compilation errors occur:

In file included from src/main.c:41:
src/codegen.c: In function ‘cfg_flatten’:
src/codegen.c:111:9: error: ‘flatten_ir’ undeclared (first use in this function); did you mean ‘fflatten_ir’?
  111 |         flatten_ir->src0 = fn->func->stack_size;
      |         ^~~~~~~~~~
      |         fflatten_ir
src/codegen.c:111:9: note: each undeclared identifier is reported only once for each function it appears in
src/codegen.c:110:19: warning: unused variable ‘fflatten_ir’ [-Wunused-variable]
  110 |         ph2_ir_t *fflatten_ir = add_ph2_ir(OP_define);
      |                   ^~~~~~~~~~~

Fix the erroneous variable name 'fflatten_ir' to 'flatten_ir' to avoid compilation errors.

The reason this error wasn't discovered in the past is because the current CI doesn't actually test the ARCH=riscv scenario. The 'make clean' command does not delete config files. This led to an issue during testing with ARCH=riscv, where 'make' used the ARCH=arm config because the config file already existed. Consequently, ARCH=arm was tested twice while ARCH=riscv wasn't tested at all.

Fix the CI by changing 'make clean' to 'make distclean' to ensure that ARCH=riscv undergoes complete testing.
