### PR TITLE
Fix some typos

### DIFF
--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -338,7 +338,7 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
         if (hard_mul_div) {
             emit(__div(__AL, rd, rm, rn));
         } else {
-            /* Obtain absoulte values of dividend and divisor */
+            /* Obtain absolute values of dividend and divisor */
             emit(__srl_amt(__AL, 0, arith_rs, __r8, rn, 31));
             emit(__add_r(__AL, rn, rn, __r8));
             emit(__eor_r(__AL, rn, rn, __r8));
@@ -375,7 +375,7 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
             emit(__mul(__AL, __r8, rm, __r8));
             emit(__sub_r(__AL, rd, rn, __r8));
         } else {
-            /* Obtain absoulte values of dividend and divisor */
+            /* Obtain absolute values of dividend and divisor */
             emit(__srl_amt(__AL, 0, arith_rs, __r8, rn, 31));
             emit(__add_r(__AL, rn, rn, __r8));
             emit(__eor_r(__AL, rn, rn, __r8));

--- a/src/arm.c
+++ b/src/arm.c
@@ -49,7 +49,7 @@ typedef enum {
     __NE = 1,  /* Not equal */
     __CS = 2,  /* Unsigned higher or same */
     __CC = 3,  /* Unsigned lower */
-    __LS = 9,  /* unsigned lower or same */
+    __LS = 9,  /* Unsigned lower or same */
     __GE = 10, /* Signed greater than or equal */
     __LT = 11, /* Signed less than */
     __GT = 12, /* Signed greater than */
@@ -82,7 +82,7 @@ typedef enum {
     logic_rs = 1, /* Logical right shift */
     arith_rs = 2, /* Arithmetic right shift */
     rotat_rs = 3  /* Rotate right shift */
-} shfit_type;
+} shift_type;
 
 arm_cond_t arm_get_cond(opcode_t op)
 {
@@ -198,7 +198,7 @@ int __srl(arm_cond_t cond, arm_reg rd, arm_reg rm, arm_reg rs)
 
 int __srl_amt(arm_cond_t cond,
               int s,
-              shfit_type shift,
+              shift_type shift,
               arm_reg rd,
               arm_reg rm,
               int amt)
@@ -215,7 +215,7 @@ int __sll(arm_cond_t cond, arm_reg rd, arm_reg rm, arm_reg rs)
 
 int __sll_amt(arm_cond_t cond,
               int s,
-              shfit_type shift,
+              shift_type shift,
               arm_reg rd,
               arm_reg rm,
               int amt)


### PR DESCRIPTION
After reviewing PR #126, I found that I wrote some typos and left unnecessary brackets when using the `if` statements, so this commit fixes them in `arm-codegen.c` and `arm.c`.