### PR TITLE
Implement dead code elimination

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -552,6 +552,7 @@ void add_insn(block_t *block,
     n->rs1 = rs1;
     n->rs2 = rs2;
     n->sz = sz;
+    n->belong_to = bb;
 
     if (str)
         strcpy(n->str, str);

--- a/src/parser.c
+++ b/src/parser.c
@@ -2608,6 +2608,8 @@ basic_block_t *read_body_statement(block_t *parent, basic_block_t *bb)
         if (body_) {
             bb_connect(body_, inc_, NEXT);
             bb_connect(inc_, cond_start, NEXT);
+        } else if (inc_->insn_list.head) {
+            bb_connect(inc_, cond_start, NEXT);
         } else {
             /* TODO: Release dangling inc basic block */
         }


### PR DESCRIPTION
The creation of RDF is based on reverse CFG. The method of building RDF is similar to building DF, but instead of iterating every `prev` nodes, it visit `next`, `then_` and `else_` nodes. The code appears to extend the for-loop to handle three cases (compared to the method of building DF). 
Due to the addition of RDF, several elements were added to the `struct basic_block`. However, `MAX_FILED` macro is not large enough, so it has been adjusted to 64.
DCE is implemented using mark-sweep algorithm. `dce_insn` marks the useful instruction and `dce_sweep` removes the operations that are not marked "useful". The `dce_insn` must execute after `cse` and `const_folding` are done because `dce_insn` may mark some instructions that are not handled by `cse` and `const_folding`. These instruction might be mistakenly mark "useful".

Related issue: #88
