### PR TITLE
Use branchless way to get rv_hi/rv_lo result

### DIFF
--- a/src/riscv.c
+++ b/src/riscv.c
@@ -112,16 +112,12 @@ int rv_extract_bits(int imm, int i_start, int i_end, int d_start, int d_end)
 
 int rv_hi(int val)
 {
-    if ((val & (1 << 11)) != 0)
-        return val + 4096;
-    return val;
+    return val + ((val & (1 << 11)) << 1);
 }
 
 int rv_lo(int val)
 {
-    if ((val & (1 << 11)) != 0)
-        return (val & 0xFFF) - 4096;
-    return val & 0xFFF;
+    return (val & 0xFFF) - ((val & (1 << 11)) << 1);
 }
 
 int rv_encode_R(rv_op op, rv_reg rd, rv_reg rs1, rv_reg rs2)


### PR DESCRIPTION
We can avoid using conditional branch via bitwise operation.    
The value of `((val & (1 << 11)) << 1)` is exactly 4096 if `(val & (1 << 11))` is true.