### PR TITLE
Optimize trie operations by replacing tail recursion with iteration

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -87,25 +87,31 @@ char *elf_section;
  */
 int insert_trie(trie_t *trie, char *name, int funcs_index)
 {
-    char first_char = *name;
-    int fc = first_char;
-    if (!fc) {
-        if (!trie->index)
-            trie->index = funcs_index;
-        return trie->index;
+    char first_char;
+    int fc;
+
+    while (1) {
+        first_char = *name;
+        fc = first_char;
+        if (!fc) {
+            if (!trie->index)
+                trie->index = funcs_index;
+            return trie->index;
+        }
+        if (!trie->next[fc]) {
+            /* FIXME: The func_tries_idx variable may exceed the maximum number,
+             * which can lead to a segmentation fault. This issue is affected by
+             * the number of functions and the length of their names. The proper
+             * way to handle this is to dynamically allocate a new element.
+             */
+            trie->next[fc] = func_tries_idx++;
+            for (int i = 0; i < 128; i++)
+                FUNC_TRIES[trie->next[fc]].next[i] = 0;
+            FUNC_TRIES[trie->next[fc]].index = 0;
+        }
+        trie = &FUNC_TRIES[trie->next[fc]];
+        name = name + 1;
     }
-    if (!trie->next[fc]) {
-        /* FIXME: The func_tries_idx variable may exceed the maximum number,
-         * which can lead to a segmentation fault. This issue is affected by the
-         * number of functions and the length of their names. The proper way to
-         * handle this is to dynamically allocate a new element.
-         */
-        trie->next[fc] = func_tries_idx++;
-        for (int i = 0; i < 128; i++)
-            FUNC_TRIES[trie->next[fc]].next[i] = 0;
-        FUNC_TRIES[trie->next[fc]].index = 0;
-    }
-    return insert_trie(&FUNC_TRIES[trie->next[fc]], name + 1, funcs_index);
 }
 
 /**
@@ -120,13 +126,19 @@ int insert_trie(trie_t *trie, char *name, int funcs_index)
  */
 int find_trie(trie_t *trie, char *name)
 {
-    char first_char = *name;
-    int fc = first_char;
-    if (!fc)
-        return trie->index;
-    if (!trie->next[fc])
-        return 0;
-    return find_trie(&FUNC_TRIES[trie->next[fc]], name + 1);
+    char first_char;
+    int fc;
+
+    while (1) {
+        first_char = *name;
+        fc = first_char;
+        if (!fc)
+            return trie->index;
+        if (!trie->next[fc])
+            return 0;
+        trie = &FUNC_TRIES[trie->next[fc]];
+        name = name + 1;
+    }
 }
 
 /* options */


### PR DESCRIPTION
Replace tail-recursive calls in insert_trie() and find_trie() with an iterative loop to reduce function call overhead and avoid potential stack overflow issues. The logic remains functionally equivalent, improving performance and stability.