### PR TITLE
Check for invalid digits when parsing octal constants

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -634,7 +634,10 @@ void read_numeric_param(block_t *parent, basic_block_t *bb, int is_neg)
             } while (is_hex(token[i]));
         } else { /* octal */
             do {
-                c = token[i++] - '0';
+                c = token[i++];
+                if (c > '7')
+                    error("Invalid numeric constant");
+                c -= '0';
                 value = (value * 8) + c;
             } while (is_digit(token[i]));
         }

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -62,6 +62,31 @@ function try_output() {
     try "$expected" "$expected_output" "$input"
 }
 
+# try_compile_error - test shecc with invalid C program
+# Usage:
+# - try_compile_error invalid_input_code
+# compile "invalid_input_code" with shecc so that shecc generates a
+# compilation error message.
+#
+# This function uses shecc to compile invalid code and obtains the exit
+# code returned by shecc. The exit code must be a non-zero value to
+# indicate that shecc has the ability to parse the invalid code and
+# output an error message.
+function try_compile_error() {
+    local input=$(cat)
+
+    local tmp_in="$(mktemp --suffix .c)"
+    local tmp_exe="$(mktemp)"
+    echo "$input" > "$tmp_in"
+    "$SHECC" -o "$tmp_exe" "$tmp_in"
+    local exit_code=$?
+
+    if [ 0 == $exit_code ]; then
+        echo "Error: compilation is passed."
+        exit 1
+    fi
+}
+
 function items() {
     local expected="$1"
     local input="$2"
@@ -235,6 +260,14 @@ int fib(int n, int a, int b)
 
 int main() {
     return fib(012, 0, 1); /* octal(12) = dec(10) */
+}
+EOF
+
+try_compile_error << EOF
+int main() {
+    int a = 03, b = 01118, c = 091;
+    printf("%d %d %d\n", a, b, c);
+    return 0;
 }
 EOF
 


### PR DESCRIPTION
After introducing the pull request (#151 ), I use the following code to test the parser:

```c
/* test.c */
int main() {
    int a = 03, b = 01118, c = 091;
    printf("%d %d %d\n", a, b, c); 
    return 0;
}
```
```
$ qemu-arm out/shecc-stage2.elf -o test test.c
$ qemu-arm test
3 592 73
```
Obviously, the octal numbers (`01118` and `091`) are invalid but the parser doesn't check whether they are valid or not.

Thus, the pull request improves the parser to enhance the validation check.