### PR TITLE
Skip symbol insertion for unreachable basic blocks

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -524,6 +524,8 @@ void bb_disconnect(basic_block_t *pred, basic_block_t *succ)
 /* The symbol is an argument of function or the variable in declaration */
 void add_symbol(basic_block_t *bb, var_t *var)
 {
+    if (!bb)
+        return;
     symbol_t *sym;
     for (sym = bb->symbol_list.head; sym; sym = sym->next) {
         if (sym->var == var)

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -271,6 +271,15 @@ int main() {
 }
 EOF
 
+# Unreachable declaration should not cause prog seg-falut (prog should leave normally with exit code 0)
+try_ 0 << EOF
+int main()
+{
+    return 0;
+    int a = 5;
+}
+EOF
+
 try_ 1 << EOF
 int is_odd(int x);
 


### PR DESCRIPTION
Previously, the compiler would throw a segmentation fault if the compiled code contained a declaration after a return statement. For example:

int main() {
    return 0;
    int a = 5;
}

This occurred when the basic block (bb) for unreachable code was null, while the function add_symbol(basic_block_t *bb, var_t *var) did not check for null before attempting to insert a variable, leading to a segmentation fault.

This commit fixes the issue by skipping symbol insertion if the basic block is unreachable (null).