### PR TITLE
Implementation of  def-use chain

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -157,6 +157,14 @@ struct ref_block_list {
 
 typedef struct ref_block_list ref_block_list_t;
 
+typedef struct insn insn_t;
+
+typedef struct use_chain_node {
+    insn_t *insn;
+    struct use_chain_node *next;
+    struct use_chain_node *prev;
+} use_chain_t;
+
 struct var {
     char type_name[MAX_TYPE_LEN];
     char var_name[MAX_VAR_LEN];
@@ -174,6 +182,8 @@ struct var {
     int subscripts_idx;
     rename_t rename;
     ref_block_list_t ref_block_list; /* blocks which kill variable */
+    use_chain_t *users_head;
+    use_chain_t *users_tail;
     struct insn *last_assign;
     int consumed;
     bool is_ternary_ret;
@@ -315,8 +325,6 @@ struct insn {
     phi_operand_t *phi_ops;
     char str[64];
 };
-
-typedef struct insn insn_t;
 
 typedef struct {
     insn_t *head;


### PR DESCRIPTION
Implement a new structure for def-use chain called `uc_node_t`. `uc_node_t` is stored within `struct var`, includes `insn` element that records the instruction using the variable which the use chain belongs to.

Simplify CSE procedure with use chain information. We build the def-use chain information by `build_use_chain` function before the optimizing phase. In addtion, When the instructions are eliminated by CSE, we delete its use chain nodes from both variables(`rs1`, `rs2`) at the same time.

The CSE method has been modified. When the first pair of instructions is found, the use chain is utilized to search for identical ADD instructions. Subsequently, the next instruction is verified to ensure it match our target. After removing the instruction, utilize the use chain to find the next target instruction.

resolve #155 