### PR TITLE
CI: Fix error when running on host-arm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,10 +34,11 @@ jobs:
     - name: build artifact
       # The GitHub Action for non-x86 CPU
       # https://github.com/uraimo/run-on-arch-action
-      uses: uraimo/run-on-arch-action@v2.7.1
+      uses: uraimo/run-on-arch-action@v2
       with:
-        arch: armv7
-        distro: ubuntu22.04
+        arch: none
+        distro: none
+        base_image: "--platform=linux/arm/v7 arm32v7/ubuntu:22.04"
         install: |
           apt-get update -q -y
           apt-get install -q -y build-essential


### PR DESCRIPTION
When pulling a base image from Docker Hub, the architecture defaults to that of the native host, which is typically x86_64 or amd64 on GitHub runners. Since the run-on-arch-action GitHub Action aims to run shecc on an Armv7 Ubuntu image, it attempts to pull the native host manifest (either x86_64 or amd64), resulting in a 'no match for platform in manifest' error unless the `--platform` option is specified. Therefore, specifying the `--platform` option as `linux/armv7` resolves this issue.