### PR TITLE
Support empty alias and refine include guard tests

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -5,6 +5,9 @@
  * file "LICENSE" for information on usage and redistribution of this file.
  */
 
+#ifndef SHECC_DEFS_H
+#define SHECC_DEFS_H
+
 /* definitions */
 
 /* Limitations */
@@ -425,3 +428,5 @@ typedef struct {
     var_t *var;
     int polluted;
 } regfile_t;
+
+#endif

--- a/src/parser.c
+++ b/src/parser.c
@@ -409,6 +409,10 @@ bool read_preproc_directive()
 
             macro->start_source_idx = source_idx;
             skip_macro_body();
+        } else {
+            /* Empty alias, may be dummy alias serves as include guard */
+            value[0] = 0;
+            add_alias(alias, value);
         }
 
         return true;

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -465,9 +465,49 @@ try_ 0 << EOF
 #else
 #define A 1
 #endif
+
+#ifndef A
+#define B 1
+#else
+#define B 0
+#endif
 int main()
 {
-    return A;
+    return A + B;
+}
+EOF
+
+# include guard test, simulates inclusion of a file named defs.h and global.c
+try_ 0 << EOF
+/* #include "defs.h" */
+#ifndef DEFS_H
+#define DEFS_H
+
+#define A 1
+
+#endif
+/* end if "defs.h" inclusion */
+
+/* #include "global.c" */
+#ifndef GLOBAL_C
+#define GLOBAL_C
+
+#define B 1
+
+/* [global.c] #include "defs.h" */
+#ifndef DEFS_H
+#define DEFS_H
+
+#define A 2
+
+#endif
+/* end if "defs.h" inclusion */
+#endif
+/* end if "global.c" inclusion */
+
+int main()
+{
+    return A - B;
 }
 EOF
 


### PR DESCRIPTION
In previous PR (#158), the include seems not to work correctly, thus, in this PR, I explicitly supports empty alias and refines previously added test case with additional include guard simulation test case.