### PR TITLE
Support escaped NULL character in string and character literal

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -304,6 +304,8 @@ token_t lex_token_internal(bool aliasing)
                     token_str[i - 1] = '\t';
                 else if (next_char == '\\')
                     token_str[i - 1] = '\\';
+                else if (next_char == '0')
+                    token_str[i - 1] = '\0';
                 else
                     abort();
             } else {
@@ -334,6 +336,8 @@ token_t lex_token_internal(bool aliasing)
                 token_str[0] = '\t';
             else if (next_char == '\\')
                 token_str[0] = '\\';
+            else if (next_char == '0')
+                token_str[0] = '\0';
             else
                 abort();
         } else {

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -630,6 +630,12 @@ int main() {
 }
 EOF
 
+try_ 0 << EOF
+int main() {
+    return '\0';
+}
+EOF
+
 # function-like macro
 try_ 1 << EOF
 #define MAX(a, b) ((a) > (b) ? (a) : (b))


### PR DESCRIPTION
As the title says, resolves #162.