### PR TITLE
Refine code generation for address-of operations

### DIFF
--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -197,6 +197,7 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
      * the instruction sequence of
      * 1. division and modulo.
      * 2. load and store operations.
+     * 3. address-of operations.
      */
     arm_reg interm;
 
@@ -219,20 +220,14 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
             emit(__mov_i(__AL, rd, ph2_ir->src0));
         return;
     case OP_address_of:
-        if (ph2_ir->src0 > 255) {
-            emit(__movw(__AL, __r8, ph2_ir->src0));
-            emit(__movt(__AL, __r8, ph2_ir->src0));
-            emit(__add_r(__AL, rd, __sp, __r8));
-        } else
-            emit(__add_i(__AL, rd, __sp, ph2_ir->src0));
-        return;
     case OP_global_address_of:
+        interm = ph2_ir->op == OP_address_of ? __sp : __r12;
         if (ph2_ir->src0 > 255) {
             emit(__movw(__AL, __r8, ph2_ir->src0));
             emit(__movt(__AL, __r8, ph2_ir->src0));
-            emit(__add_r(__AL, rd, __r12, __r8));
+            emit(__add_r(__AL, rd, interm, __r8));
         } else
-            emit(__add_i(__AL, rd, __r12, ph2_ir->src0));
+            emit(__add_i(__AL, rd, interm, ph2_ir->src0));
         return;
     case OP_assign:
         emit(__mov_r(__AL, rd, rn));

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -161,6 +161,7 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
      * the instruction sequence of
      * 1. division and modulo.
      * 2. load and store operations.
+     * 3. address-of operations.
      */
     rv_reg interm, divisor_mask = __t1;
 
@@ -179,21 +180,15 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
         } else
             emit(__addi(rd, __zero, ph2_ir->src0));
         return;
-    case OP_global_address_of:
-        if (ph2_ir->src0 < -2048 || ph2_ir->src0 > 2047) {
-            emit(__lui(__t0, rv_hi(ph2_ir->src0)));
-            emit(__addi(__t0, __t0, rv_lo(ph2_ir->src0)));
-            emit(__add(rd, __gp, __t0));
-        } else
-            emit(__addi(rd, __gp, ph2_ir->src0));
-        return;
     case OP_address_of:
+    case OP_global_address_of:
+        interm = ph2_ir->op == OP_address_of ? __sp : __gp;
         if (ph2_ir->src0 < -2048 || ph2_ir->src0 > 2047) {
             emit(__lui(__t0, rv_hi(ph2_ir->src0)));
             emit(__addi(__t0, __t0, rv_lo(ph2_ir->src0)));
-            emit(__add(rd, __sp, __t0));
+            emit(__add(rd, interm, __t0));
         } else
-            emit(__addi(rd, __sp, ph2_ir->src0));
+            emit(__addi(rd, interm, ph2_ir->src0));
         return;
     case OP_assign:
         emit(__addi(rd, rs1, 0));


### PR DESCRIPTION
Upon further observation, I noticed that the instruction sequences of address-of and global address-of are highly similar and can be refined.

The proposed changes resemble my previous pull request (#167), but were discovered later, which is why I am submitting this pull request for improvement.