### PR TITLE
Fix bad logical-or implementation

### DIFF
--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -106,7 +106,6 @@ void update_elf_offset(ph2_ir_t *ph2_ir)
     case OP_geq:
     case OP_leq:
     case OP_log_not:
-    case OP_log_or:
         elf_offset += 12;
         return;
     case OP_branch:
@@ -117,9 +116,6 @@ void update_elf_offset(ph2_ir_t *ph2_ir)
         return;
     case OP_return:
         elf_offset += 24;
-        return;
-    case OP_log_and:
-        elf_offset += 28;
         return;
     default:
         printf("Unknown opcode\n");
@@ -423,11 +419,6 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
         emit(__teq(rn));
         emit(__mov_i(__NE, rd, 0));
         emit(__mov_i(__EQ, rd, 1));
-        return;
-    case OP_log_or:
-        emit(__or_r(__AL, rd, rn, rm));
-        emit(__teq(rd));
-        emit(__mov_i(__NE, rd, 1));
         return;
     default:
         printf("Unknown opcode\n");

--- a/src/defs.h
+++ b/src/defs.h
@@ -23,7 +23,7 @@
 #define MAX_FUNC_TRIES 2160
 #define MAX_BLOCKS 2048
 #define MAX_TYPES 64
-#define MAX_IR_INSTR 40000
+#define MAX_IR_INSTR 50000
 #define MAX_BB_PRED 128
 #define MAX_BB_DOM_SUCC 64
 #define MAX_BB_RDOM_SUCC 256
@@ -190,7 +190,7 @@ struct var {
     struct insn *last_assign;
     int consumed;
     bool is_ternary_ret;
-    bool is_log_and_ret;
+    bool is_logical_ret;
     bool is_const; /* whether a constant representaion or not */
 };
 

--- a/src/reg-alloc.c
+++ b/src/reg-alloc.c
@@ -574,8 +574,6 @@ void reg_alloc()
                 case OP_bit_and:
                 case OP_bit_or:
                 case OP_bit_xor:
-                case OP_log_and:
-                case OP_log_or:
                     src0 = prepare_operand(bb, insn->rs1, -1);
                     src1 = prepare_operand(bb, insn->rs2, src0);
                     dest = prepare_dest(bb, insn->rd, src0, src1);
@@ -766,12 +764,6 @@ void dump_ph2_ir()
             break;
         case OP_bit_xor:
             printf("\t%%x%c = xor %%x%c, %%x%c", rd, rs1, rs2);
-            break;
-        case OP_log_and:
-            printf("\t%%x%c = and %%x%c, %%x%c", rd, rs1, rs2);
-            break;
-        case OP_log_or:
-            printf("\t%%x%c = or %%x%c, %%x%c", rd, rs1, rs2);
             break;
         case OP_log_not:
             printf("\t%%x%c = not %%x%c", rd, rs1);

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -79,7 +79,6 @@ void update_elf_offset(ph2_ir_t *ph2_ir)
     case OP_geq:
     case OP_leq:
     case OP_log_not:
-    case OP_log_or:
         elf_offset += 8;
         return;
     case OP_address_of_func:
@@ -89,7 +88,6 @@ void update_elf_offset(ph2_ir_t *ph2_ir)
     case OP_branch:
         elf_offset += 20;
         return;
-    case OP_log_and:
     case OP_return:
         elf_offset += 24;
         return;
@@ -396,10 +394,6 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
     case OP_log_not:
         emit(__sltu(rd, __zero, rs1));
         emit(__xori(rd, rd, 1));
-        return;
-    case OP_log_or:
-        emit(__or(rd, rs1, rs2));
-        emit(__sltu(rd, __zero, rd));
         return;
     default:
         printf("Unknown opcode\n");

--- a/src/ssa.c
+++ b/src/ssa.c
@@ -644,14 +644,14 @@ void solve_phi_insertion()
                     if (insert_phi_insn(df, var)) {
                         bool found = false;
 
-                        /* Restrict phi insertion of ternary operation and
-                         * logical-and operation.
+                        /* Restrict phi insertion of ternary operation, and
+                         * logical-and/or operation.
                          *
-                         * The ternary and logical-and operation doesn't create
-                         * new scope, so prevent temporary variable from
+                         * The ternary and logical-and/or operations don't
+                         * create new scope, so prevent temporary variable from
                          * propagating through the dominance tree.
                          */
-                        if (var->is_ternary_ret || var->is_log_and_ret)
+                        if (var->is_ternary_ret || var->is_logical_ret)
                             continue;
 
                         for (int l = 0; l < work_list_idx; l++)


### PR DESCRIPTION
Because the current shecc still generates bitwise-or instructions for logical-or operations, the proposed changes improve both the frontend and backend so that it generates branch instructions for logical-or operations.

The new implementation obeys short-circuit principle; that is, once the first operand is true, the second operand is not evaluated. Also, the proposed changes add some test cases the validate the correctness.
