### PR TITLE
Replace fixed size blocks with linked list

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -21,7 +21,6 @@
 #define MAX_FIELDS 64
 #define MAX_FUNCS 512
 #define MAX_FUNC_TRIES 2160
-#define MAX_BLOCKS 2048
 #define MAX_TYPES 64
 #define MAX_IR_INSTR 50000
 #define MAX_BB_PRED 128
@@ -227,10 +226,15 @@ struct block {
     func_t *func;
     macro_t *macro;
     int locals_size;
-    int index;
+    struct block *next;
 };
 
 typedef struct block block_t;
+
+typedef struct {
+    block_t *head;
+    block_t *tail;
+} block_list_t;
 
 /* phase-1 IR definition */
 typedef struct {

--- a/src/parser.c
+++ b/src/parser.c
@@ -2153,7 +2153,7 @@ bool read_global_assignment(char *token)
 {
     ph1_ir_t *ph1_ir;
     var_t *vd;
-    block_t *parent = &BLOCKS[0];
+    block_t *parent = BLOCKS.head;
 
     /* global initialization must be constant */
     var_t *var = find_global_var(token);
@@ -3182,7 +3182,7 @@ void read_global_decl(block_t *block)
 void read_global_statement()
 {
     char token[MAX_ID_LEN];
-    block_t *block = &BLOCKS[0]; /* global block */
+    block_t *block = BLOCKS.head; /* global block */
 
     if (lex_accept(T_struct)) {
         int i = 0, size = 0;


### PR DESCRIPTION
This PR adjusts size of blocks array based on demand instead of using a constant, to prevent potential insufficient allocation issues in the future work, also reduces memory usage when compiling small programs.

I use `/usr/bin/time -v ./out/shecc tests/hello.c` to benchmark the usage of memory:

Before:
```shell
Command being timed: "./out/shecc tests/hello.c"
        User time (seconds): 0.00
        System time (seconds): 0.06
        Percent of CPU this job got: 93%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.07
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 224528
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 11436
        Voluntary context switches: 2
        Involuntary context switches: 0
        Swaps: 0
        File system inputs: 16
        File system outputs: 32
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
``` 

After:
```shell
Command being timed: "./out/shecc tests/hello.c"
        User time (seconds): 0.00
        System time (seconds): 0.02
        Percent of CPU this job got: 100%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.02
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 51852
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 12204
        Voluntary context switches: 1
        Involuntary context switches: 1
        Swaps: 0
        File system inputs: 0
        File system outputs: 32
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```