### PR TITLE
Replace func trie with hashmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC ?= gcc
 CFLAGS := -O -g \
 	-std=c99 -pedantic \
+	-fwrapv \
 	-Wall -Wextra \
 	-Wno-unused-but-set-variable \
 	-Wno-variadic-macros \

--- a/src/defs.h
+++ b/src/defs.h
@@ -20,7 +20,6 @@
 #define MAX_LOCALS 1500
 #define MAX_FIELDS 64
 #define MAX_FUNCS 512
-#define MAX_FUNC_TRIES 2160
 #define MAX_TYPES 64
 #define MAX_IR_INSTR 50000
 #define MAX_BB_PRED 128
@@ -305,10 +304,18 @@ typedef struct {
     int value;
 } constant_t;
 
+/* string-based hash map definitions */
+
+typedef struct hashmap_node {
+    char *key;
+    void *val;
+    struct hashmap_node *next;
+} hashmap_node_t;
+
 typedef struct {
-    int index;
-    int next[128];
-} trie_t;
+    int size;
+    hashmap_node_t **buckets;
+} hashmap_t;
 
 struct phi_operand {
     var_t *var;


### PR DESCRIPTION
Previously, trie implementation is not consistent, mainly because of using index to point the referencing `func_t` to `FUNCS`, additionally, it lacks of dynamic allocation which might cause segmentation fault and results more technical debt to debug on either `FUNCS` or `FUNCS_TRIE`. Thus, in this PR, we can resolve this issue by introducing a dynamic hashmap.

Current implementation is using [FNV-1a](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1a_hash) hashing algorithm (32-bit edition to be precise), and due to lack of unsigned integer implementation, hashing result ranges from `0` to `2,147,483,647`.

Notice that current implementation may suffer from lookup issue when the function amount keeps increasing since current hashmap implementation doesn't offer rehashing based on load factor (which ideally, 0.75 would be best and currently shecc does not support floating number).

This also enables us to refactor more structures later with hashmap implementation in shecc.

<details>

<summary>Benchmark for ./tests/hello.c compilation</summary>

### Before

```shell
Command being timed: "./out/shecc tests/hello.c"
        User time (seconds): 0.00
        System time (seconds): 0.02
        Percent of CPU this job got: 76%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.03
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 52112
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 12220
        Voluntary context switches: 0
        Involuntary context switches: 0
        Swaps: 0
        File system inputs: 0
        File system outputs: 32
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

### After

```shell
Command being timed: "./out/shecc tests/hello.c"
        User time (seconds): 0.00
        System time (seconds): 0.02
        Percent of CPU this job got: 71%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.03
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 49916
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 12224
        Voluntary context switches: 1
        Involuntary context switches: 0
        Swaps: 0
        File system inputs: 8
        File system outputs: 32
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

</details> 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request replaces the trie structure for function lookups with a dynamic hashmap, improving memory management and addressing segmentation faults. The new implementation uses the FNV-1a hashing algorithm but currently lacks dynamic resizing, which may impact performance as function count increases. Overall, it simplifies function storage and sets the stage for future enhancements.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>