### PR TITLE
Codebase cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ a.out
 config
 src/codegen.c
 .session.mk
+
+# vscode C/C++ plugin generated files
+.vscode

--- a/src/globals.c
+++ b/src/globals.c
@@ -5,6 +5,9 @@
  * file "LICENSE" for information on usage and redistribution of this file.
  */
 
+#include <stdbool.h>
+#include <stdlib.h>
+
 /* Global objects */
 
 block_list_t BLOCKS;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -5,6 +5,8 @@
  * file "LICENSE" for information on usage and redistribution of this file.
  */
 
+#include <stdbool.h>
+
 /* lexer tokens */
 typedef enum {
     T_start, /* FIXME: it was intended to start the state machine. */

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,6 +5,9 @@
  * file "LICENSE" for information on usage and redistribution of this file.
  */
 
+#include <stdbool.h>
+#include <stdlib.h>
+
 /* C language syntactic analyzer */
 int global_var_idx = 0;
 int global_label_idx = 0;


### PR DESCRIPTION
Due to current shecc's implementation, modern editors with common lsp such as VSCode with C/C++ plugin is unable to properly analyze from main.c, even though the code is correct. Thus we adds some system header inclusion in certain files to resolve and suppress error message. Notice that due to current frontend's limitation, including defs.h in C source files other than main.c would result weird error, thus this is not introduced in this commit.

In addition, it's annoying that VSCode always generate .vscode folder with some plugin-specific setting config files. Therefore, we also ignore it to prevent accidentally adding the config file to stage.