### PR TITLE
Fix dereference behavior on mixed subscript and arrow / dot operators

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -250,9 +250,7 @@ void hashmap_free(hashmap_t *map)
             next = cur->next;
             free(cur->key);
             free(cur->val);
-            /* FIXME: Remove this if-clause will cause double free error */
-            if (cur != map->buckets[0])
-                free(cur);
+            free(cur);
             cur = next;
         }
     }

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -433,6 +433,49 @@ int main() {
 }
 EOF
 
+# Mixed subscript and arrow / dot operators,
+# excerpted and modified from issue #165
+try_output 0 "DDDDDDMMMEEE1" << EOF
+#include <stdlib.h>
+#include <string.h>
+
+char a[100];
+
+typedef struct {
+    char *raw;
+} data_t;
+
+int main() {
+    strcpy(a, "DATA");
+    data_t *data = malloc(sizeof(data_t));
+    data->raw = a;
+    data_t data2;
+    data2.raw = a;
+    char *raw = data->raw;
+    char *raw2 = data2.raw;
+    /* mixed arrow / dot with subscript operators dereference */
+    printf("%c", a[0]);
+    printf("%c", raw[0]);
+    printf("%c", data->raw[0]);
+    printf("%c", a[0]);
+    printf("%c", raw2[0]);
+    printf("%c", data2.raw[0]);
+    /* mixed arrow / dot with subscript operators assignment */
+    data2.raw[0] = 'M';
+    data->raw[1] = 'E';
+    printf("%c", a[0]);
+    printf("%c", raw[0]);
+    printf("%c", data->raw[0]);
+    printf("%c", a[1]);
+    printf("%c", raw2[1]);
+    printf("%c", data2.raw[1]);
+    /* their addresses should be same */
+    printf("%d", &data2.raw[0] == &data->raw[0]);
+    free(data);
+    return 0;
+}
+EOF
+
 # global initialization
 try_ 20 << EOF
 int a = 5 * 2;


### PR DESCRIPTION
- Fix #165.
- Fix #181, as it's already introduced into upstream source code by #179.
- Fix #164.
- This change could hopefully allow us to safely operate more dynamic data strctures without having troubles. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request fixes a double free error in the globals file and enhances type safety in the parser by changing variable types from int to bool. It also introduces new tests for dynamic data structures, improving the robustness of the codebase and addressing issues #165, #181, and #164.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>