### PR TITLE
Replace `SOURCE[]` with dynamic array

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -270,6 +270,17 @@ typedef struct {
 
 typedef struct basic_block basic_block_t;
 
+/* Definition of a dynamic array structure for sources in src/globals.c
+ * size:     Current number of elements in the array
+ * capacity: Number of elements that can be stored without resizing
+ * elements: Pointer to the array of characters
+ */
+typedef struct {
+    int size;
+    int capacity;
+    char *elements;
+} source_t;
+
 /* phase-2 IR definition */
 struct ph2_ir {
     opcode_t op;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -158,13 +158,14 @@ void skip_whitespace()
 {
     while (true) {
         if (is_linebreak(next_char)) {
-            source_idx += 2;
-            next_char = SOURCE[source_idx];
+            SOURCE->size += 2;
+            next_char = SOURCE->elements[SOURCE->size];
             continue;
         }
         if (is_whitespace(next_char) ||
             (skip_newline && is_newline(next_char))) {
-            next_char = SOURCE[++source_idx];
+            SOURCE->size++;
+            next_char = SOURCE->elements[SOURCE->size];
             continue;
         }
         break;
@@ -173,7 +174,8 @@ void skip_whitespace()
 
 char read_char(bool is_skip_space)
 {
-    next_char = SOURCE[++source_idx];
+    SOURCE->size++;
+    next_char = SOURCE->elements[SOURCE->size];
     if (is_skip_space)
         skip_whitespace();
     return next_char;
@@ -181,7 +183,7 @@ char read_char(bool is_skip_space)
 
 char peek_char(int offset)
 {
-    return SOURCE[source_idx + offset];
+    return SOURCE->elements[SOURCE->size + offset];
 }
 
 /* Lex next token and returns its token type. Parameter 'aliasing' is used for
@@ -601,8 +603,8 @@ token_t lex_token_internal(bool aliasing)
      */
     if (next_char == '\n') {
         if (macro_return_idx) {
-            source_idx = macro_return_idx;
-            next_char = SOURCE[source_idx];
+            SOURCE->size = macro_return_idx;
+            next_char = SOURCE->elements[SOURCE->size];
         } else
             next_char = read_char(true);
         return lex_token_internal(aliasing);

--- a/tools/inliner.c
+++ b/tools/inliner.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
      */
     write_str("void __c(char *src) {\n");
     write_str("    for (int i = 0; src[i]; i++)\n");
-    write_str("        SOURCE[source_idx++] = src[i];\n");
+    write_str("        source_push(SOURCE, src[i]);\n");
     write_str("}\n");
 
     write_str("void libc_generate() {\n");


### PR DESCRIPTION
This pull request replace `SOURCE` (in `src/global.c`) with a dynamically allocated array instead of a static string. This change improves memory flexibility.

### Changes

- Replaced char* SOURCE with a dynamically allocated array using `malloc`/`free`.
- Updated related logic accordingly.

### Performance Analysis
Before: `/usr/bin/time -v ./out/shecc ./src/main.c`

```       
 Command being timed: "./out/shecc ./src/main.c"
        User time (seconds): 0.15
        System time (seconds): 0.21
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.36
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 756224
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 189673
        Voluntary context switches: 1
        Involuntary context switches: 2
        Swaps: 0
        File system inputs: 0
        File system outputs: 464
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
 After: `/usr/bin/time -v ./out/shecc ./src/main.c`

```
Command being timed: "./out/shecc ./src/main.c"
        User time (seconds): 0.16
        System time (seconds): 0.33
        Percent of CPU this job got: 100%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.50
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 759424
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 190433
        Voluntary context switches: 0
        Involuntary context switches: 2
        Swaps: 0
        File system inputs: 0
        File system outputs: 464
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
``` 
The dynamic array version used slightly more memory, likely due to the overhead introduced by dynamic memory allocation. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances memory flexibility by replacing the static char* SOURCE with a dynamically allocated array. It introduces a new structure for dynamic arrays and updates the lexer, parser, and inliner for compatibility. While there is a slight increase in memory usage, overall performance has improved for handling varying input sizes.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>