### PR TITLE
Overhaul `hashmap_t` functionalities

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -78,6 +78,20 @@ typedef struct {
     arena_block_t *head;
 } arena_t;
 
+/* string-based hash map definitions */
+
+typedef struct hashmap_node {
+    char *key;
+    void *val;
+    struct hashmap_node *next;
+} hashmap_node_t;
+
+typedef struct {
+    int size;
+    int cap;
+    hashmap_node_t **buckets;
+} hashmap_t;
+
 /* builtin types */
 typedef enum {
     TYPE_void = 0,
@@ -330,19 +344,6 @@ typedef struct {
     char alias[MAX_VAR_LEN];
     int value;
 } constant_t;
-
-/* string-based hash map definitions */
-
-typedef struct hashmap_node {
-    char *key;
-    void *val;
-    struct hashmap_node *next;
-} hashmap_node_t;
-
-typedef struct {
-    int size;
-    hashmap_node_t **buckets;
-} hashmap_t;
 
 struct phi_operand {
     var_t *var;


### PR DESCRIPTION
This patch fixes constracts of `hashmap_t`-related function, including:

- `hashmap_contains`: Instead of delegates to result returned by `hashmap_get`, now shares similar logic to avoid bucket node value being `NULL` and treat as false.
- ~~`hashmap_free`: Now respects bucket node value's pointer, if it's already `NULL`, then hashmap won't free it.~~

Additionally, now `hashmap_t `is capable of rehashing its underlying bucket node array when load factor reaches **75%**.

Closes #190. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the `hashmap_t` functionalities by implementing a rehashing mechanism triggered at a 75% load factor, refining the `hashmap_contains` logic to avoid incorrect NULL returns, and updating `hashmap_free` for better memory management. These improvements optimize the performance and reliability of the hashmap, ensuring a more robust implementation.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>