### PR TITLE
Cleanup `source_t` codebase & fix usage

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3428,8 +3428,7 @@ void load_source_file(char *file)
             snprintf(path + c + 1, inclusion_path_len, "%s", buffer + 10);
             load_source_file(path);
         } else {
-            strcpy(SOURCE->elements + SOURCE->size, buffer);
-            SOURCE->size += strlen(buffer);
+            source_push_str(SOURCE, buffer);
         }
     }
 


### PR DESCRIPTION
Previously `SOURCE` is overhauled with a dynamic array implementation, but `parser.c` and `inliner.c` didn't actually benefited from it, and could still cause overflow if size exceeds capacity.

In this patch, now extending `source_t` respects computed result size and expands if need. `inliner.c`'s implementation is now also replaced with dynamic array implementation.

Additionally, few functions are renamed to keep function naming convention. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the `source_t` structure by implementing a dynamic array for better memory management and preventing overflow issues. It also renames several functions for consistency, improving code clarity and maintainability across `parser.c` and `inliner.c`.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve structural improvements and renaming, making the review process relatively simple.
</div>