### PR TITLE
Improve the ELF generation process

### DIFF
--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -179,7 +179,7 @@ void cfg_flatten()
 
 void emit(int code)
 {
-    elf_write_code_int(code);
+    elf_write_int(elf_code, code);
 }
 
 void emit_ph2_ir(ph2_ir_t *ph2_ir)
@@ -271,16 +271,16 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
         emit(__teq(rn));
         if (ph2_ir->is_branch_detached) {
             emit(__b(__NE, 8));
-            emit(__b(__AL, ph2_ir->else_bb->elf_offset - elf_code_idx));
+            emit(__b(__AL, ph2_ir->else_bb->elf_offset - elf_code->size));
         } else
-            emit(__b(__NE, ph2_ir->then_bb->elf_offset - elf_code_idx));
+            emit(__b(__NE, ph2_ir->then_bb->elf_offset - elf_code->size));
         return;
     case OP_jump:
-        emit(__b(__AL, ph2_ir->next_bb->elf_offset - elf_code_idx));
+        emit(__b(__AL, ph2_ir->next_bb->elf_offset - elf_code->size));
         return;
     case OP_call:
         func = find_func(ph2_ir->func_name);
-        emit(__bl(__AL, func->bbs->elf_offset - elf_code_idx));
+        emit(__bl(__AL, func->bbs->elf_offset - elf_code->size));
         return;
     case OP_load_data_address:
         emit(__movw(__AL, rd, ph2_ir->src0 + elf_data_start));
@@ -436,7 +436,7 @@ void code_generate()
     emit(__movt(__AL, __r8, GLOBAL_FUNC->stack_size));
     emit(__sub_r(__AL, __sp, __sp, __r8));
     emit(__mov_r(__AL, __r12, __sp));
-    emit(__bl(__AL, GLOBAL_FUNC->bbs->elf_offset - elf_code_idx));
+    emit(__bl(__AL, GLOBAL_FUNC->bbs->elf_offset - elf_code->size));
 
     /* exit */
     emit(__movw(__AL, __r8, GLOBAL_FUNC->stack_size));
@@ -468,7 +468,7 @@ void code_generate()
     emit(__add_r(__AL, __r8, __r12, __r8));
     emit(__lw(__AL, __r0, __r8, 0));
     emit(__add_i(__AL, __r1, __r8, 4));
-    emit(__b(__AL, MAIN_BB->elf_offset - elf_code_idx));
+    emit(__b(__AL, MAIN_BB->elf_offset - elf_code->size));
 
     for (int i = 0; i < ph2_ir_idx; i++) {
         ph2_ir = PH2_IR_FLATTEN[i];

--- a/src/defs.h
+++ b/src/defs.h
@@ -351,7 +351,7 @@ typedef struct {
 
 typedef struct basic_block basic_block_t;
 
-/* Definition of a dynamic array structure for sources in src/globals.c
+/* Definition of a growable buffer for a mutable null-terminated string
  * size:     Current number of elements in the array
  * capacity: Number of elements that can be stored without resizing
  * elements: Pointer to the array of characters
@@ -360,7 +360,7 @@ typedef struct {
     int size;
     int capacity;
     char *elements;
-} source_t;
+} strbuf_t;
 
 /* phase-2 IR definition */
 struct ph2_ir {

--- a/src/defs.h
+++ b/src/defs.h
@@ -547,3 +547,48 @@ typedef struct {
     var_t *var;
     int polluted;
 } regfile_t;
+
+/* FIXME: replace char[2] with a short data type in ELF header structures */
+/* ELF header */
+typedef struct {
+    char e_ident[16];
+    char e_type[2];
+    char e_machine[2];
+    int e_version;
+    int e_entry;
+    int e_phoff;
+    int e_shoff;
+    int e_flags;
+    char e_ehsize[2];
+    char e_phentsize[2];
+    char e_phnum[2];
+    char e_shentsize[2];
+    char e_shnum[2];
+    char e_shstrndx[2];
+} elf32_hdr_t;
+
+/* ELF program header */
+typedef struct {
+    int p_type;
+    int p_offset;
+    int p_vaddr;
+    int p_paddr;
+    int p_filesz;
+    int p_memsz;
+    int p_flags;
+    int p_align;
+} elf32_phdr_t;
+
+/* ELF section header */
+typedef struct {
+    int sh_name;
+    int sh_type;
+    int sh_flags;
+    int sh_addr;
+    int sh_offset;
+    int sh_size;
+    int sh_link;
+    int sh_info;
+    int sh_addralign;
+    int sh_entsize;
+} elf32_shdr_t;

--- a/src/elf.c
+++ b/src/elf.c
@@ -15,7 +15,7 @@ void elf_write_str(strbuf_t *elf_array, char *vals)
      * Note that strbuf_puts() does not push the null character.
      *
      * If necessary, use elf_write_byte() to append the null character
-     * after calling strbuf_puts().
+     * after calling elf_write_str().
      */
     strbuf_puts(elf_array, vals);
 }
@@ -36,53 +36,137 @@ void elf_write_int(strbuf_t *elf_array, int val)
         strbuf_putc(elf_array, e_extract_byte(val, i));
 }
 
+void elf_write_blk(strbuf_t *elf_array, void *blk, int sz)
+{
+    char *ptr = blk;
+    for (int i = 0; i < sz; i++)
+        strbuf_putc(elf_array, ptr[i]);
+}
+
 void elf_generate_header()
 {
-    /* ELF header */
-    elf_write_int(elf_header, 0x464c457f); /* Magic: 0x7F followed by ELF */
-    elf_write_byte(elf_header, 1);         /* 32-bit */
-    elf_write_byte(elf_header, 1);         /* little-endian */
-    elf_write_byte(elf_header, 1);         /* EI_VERSION */
-    elf_write_byte(elf_header, 0);         /* System V */
-    elf_write_int(elf_header, 0);          /* EI_ABIVERSION */
-    elf_write_int(elf_header, 0);          /* EI_PAD: unused */
-    elf_write_byte(elf_header, 2);         /* ET_EXEC */
-    elf_write_byte(elf_header, 0);
-    elf_write_byte(elf_header, ELF_MACHINE);
-    elf_write_byte(elf_header, 0);
-    elf_write_int(elf_header, 1);                          /* ELF version */
-    elf_write_int(elf_header, ELF_START + elf_header_len); /* entry point */
-    elf_write_int(elf_header, 0x34); /* program header offset */
-    elf_write_int(elf_header, elf_header_len + elf_code->size + elf_data->size +
-                                  39 + elf_symtab->size +
-                                  elf_strtab->size); /* section header offset */
-    /* flags */
-    elf_write_int(elf_header, ELF_FLAGS);
-    elf_write_byte(elf_header, 0x34); /* header size */
-    elf_write_byte(elf_header, 0);
-    elf_write_byte(elf_header, 0x20); /* program header size */
-    elf_write_byte(elf_header, 0);
-    elf_write_byte(elf_header, 1); /* number of program headers */
-    elf_write_byte(elf_header, 0);
-    elf_write_byte(elf_header, 0x28); /* section header size */
-    elf_write_byte(elf_header, 0);
-    elf_write_byte(elf_header, 6); /* number of sections */
-    elf_write_byte(elf_header, 0);
-    elf_write_byte(elf_header, 5); /* section index with names */
-    elf_write_byte(elf_header, 0);
+    elf32_hdr_t hdr;
+    /*
+     * The following table explains the meaning of each field in the
+     * ELF32 file header.
+     *
+     * Notice that the following values are hexadecimal.
+     *
+     *    |  File          |                                                 |
+     *  & |  Header bytes  | Explanation                                     |
+     * ---+----------------+-------------------------------------------------+
+     * 00 | 7F  45  4C  46 | e_ident[0] - e_ident[3]: ELF magic number.      |
+     *    | 01             | e_ident[4]: 1 -> 32-bit, 2 -> 64-bit.           |
+     *    |     01         | e_ident[5]: 1 -> little-endian. 2 -> big-endian.|
+     *    |         01     | e_ident[6]: 1 -> ELF header version; must be 1. |
+     *    |             00 | e_ident[7]: Target OS ABI; be 1 for Linux.      |
+     *    | 00             | e_ident[8]: ABI version; should be 1 for Linux. |
+     *    |     00  00  00 | e_ident[9] - e_ident[16]: Padding; Unused;      |
+     *    | 00  00  00  00 |                           should be 0.          |
+     * ---+----------------+-------------------------------------------------+
+     *    | 02  00         | e_type: Object file type; 2 -> executable       |
+     *    |         28  00 | e_machine: Instruction Set Architecture.        |
+     *    |                |            0x28 -> ARMv7                        |
+     *    |                |            0xF3 -> RISC-V                       |
+     *    | 01  00  00  00 | e_version: ELF identification version;          |
+     *    |                |            must be 1.                           |
+     *    | 54  00  01  00 | e_entry: Memory address of entry point.         |
+     *    |                |          (where process starts).                |
+     *    | 34  00  00  00 | e_phoff: File offset of program headers.        |
+     *    |                |          0x34 -> 32-bit, 0x40 -> 64-bit.        |
+     *    | d7  8a  03  00 | e_shoff: File offset of section headers.        |
+     * ---+----------------+-------------------------------------------------+
+     *    | 00  02  00  50 | e_flags: 0x50000200 -> ARM Version5 EABI,       |
+     *    |                |                        soft-float ABI           |
+     *    |                |          0x00000000 -> RISC-V                   |
+     *    | 34  00         | e_ehsize: Size of this header.                  |
+     *    |                |           0x34 -> 32-bit, 0x40 -> 64-bit.       |
+     *    |         20  00 | e_phentsize: Size of each program header.       |
+     *    |                |              0x20 -> 32-bit, 0x38 -> 64-bit.    |
+     *    | 01  00         | e_phnum: Number of program headers.             |
+     *    |         28  00 | e_shentsize: Size of each section header.       |
+     *    |                |              0x28 -> 32-bit, 0x40 -> 64-bit.    |
+     *    | 06  00         | e_shnum: Number of section headers.             |
+     *    |         05  00 | e_shstrndx: Index of section header containing  |
+     *    |                |             section names.                      |
+     * ---+----------------+-------------------------------------------------+
+     * 34 |                |                                                 |
+     */
+    /* ELF file header */
+    hdr.e_ident[0] = 0x7F; /* ELF magic number */
+    hdr.e_ident[1] = 'E';
+    hdr.e_ident[2] = 'L';
+    hdr.e_ident[3] = 'F';
+    hdr.e_ident[4] = 1; /* 32-bit */
+    hdr.e_ident[5] = 1; /* little-endian */
+    hdr.e_ident[6] = 1; /* ELF header version */
+    hdr.e_ident[7] = 0; /* Target OS ABI */
+    hdr.e_ident[8] = 0; /* ABI version */
+    hdr.e_ident[9] = 0; /* Padding */
+    hdr.e_ident[10] = 0;
+    hdr.e_ident[11] = 0;
+    hdr.e_ident[12] = 0;
+    hdr.e_ident[13] = 0;
+    hdr.e_ident[14] = 0;
+    hdr.e_ident[15] = 0;
+    hdr.e_type[0] = 2; /* Object file type */
+    hdr.e_type[1] = 0;
+    hdr.e_machine[0] = ELF_MACHINE; /* Instruction Set Architecture */
+    hdr.e_machine[1] = 0;
+    hdr.e_version = 1;                        /* ELF version */
+    hdr.e_entry = ELF_START + elf_header_len; /* entry point */
+    hdr.e_phoff = 0x34;                       /* program header offset */
+    hdr.e_shoff = elf_header_len + elf_code->size + elf_data->size + 39 +
+                  elf_symtab->size +
+                  elf_strtab->size; /* section header offset */
+    hdr.e_flags = ELF_FLAGS;        /* flags */
+    hdr.e_ehsize[0] = 0x34;         /* header size */
+    hdr.e_ehsize[1] = 0;
+    hdr.e_phentsize[0] = 0x20; /* program header size */
+    hdr.e_phentsize[1] = 0;
+    hdr.e_phnum[0] = 1; /* number of program headers */
+    hdr.e_phnum[1] = 0;
+    hdr.e_shentsize[0] = 0x28; /* section header size */
+    hdr.e_shentsize[1] = 0;
+    hdr.e_shnum[0] = 6; /* number of section headers */
+    hdr.e_shnum[1] = 0;
+    hdr.e_shstrndx[0] = 5; /* section index with names */
+    hdr.e_shstrndx[1] = 0;
+    elf_write_blk(elf_header, &hdr, sizeof(elf32_hdr_t));
 
+    /*
+     * Explain the meaning of each field in the ELF32 program header.
+     *
+     *    |  Program       |                                                 |
+     *  & |  Header bytes  | Explanation                                     |
+     * ---+----------------+-------------------------------------------------+
+     * 34 | 01  00  00  00 | p_type: Segment type; 1 -> loadable.            |
+     *    | 54  00  00  00 | p_offset: Offset of segment in the file.        |
+     *    | 54  00  01  00 | p_vaddr: Virtual address of loaded segment.     |
+     *    | 54  00  01  00 | p_paddr: Only used on systems where physical    |
+     *    |                |          address is relevant.                   |
+     *    | 48  8a  03  00 | p_filesz: Size of the segment in the file image.|
+     *    | 48  8a  03  00 | p_memsz: Size of the segment in memory.         |
+     *    |                |          This value should be greater than or   |
+     *    |                |          equal to p_filesz.                     |
+     *    | 07  00  00  00 | p_flags: Segment-wise permissions;              |
+     *    |                |          0x1 -> execute, 0x2 -> write,          |
+     *    |                |          0x4 -> read                            |
+     *    | 04  00  00  00 | p_align: Align segment to the specified value.  |
+     * ---+----------------+-------------------------------------------------+
+     * 54 |                |                                                 |
+     */
     /* program header - code and data combined */
-    elf_write_int(elf_header, 1);              /* PT_LOAD */
-    elf_write_int(elf_header, elf_header_len); /* offset of segment */
-    elf_write_int(elf_header, ELF_START + elf_header_len); /* virtual address */
-    elf_write_int(elf_header,
-                  ELF_START + elf_header_len); /* physical address */
-    elf_write_int(elf_header,
-                  elf_code->size + elf_data->size); /* size in file */
-    elf_write_int(elf_header,
-                  elf_code->size + elf_data->size); /* size in memory */
-    elf_write_int(elf_header, 7);                   /* flags */
-    elf_write_int(elf_header, 4);                   /* alignment */
+    elf32_phdr_t phdr;
+    phdr.p_type = 1;                                 /* PT_LOAD */
+    phdr.p_offset = elf_header_len;                  /* offset of segment */
+    phdr.p_vaddr = ELF_START + elf_header_len;       /* virtual address */
+    phdr.p_paddr = ELF_START + elf_header_len;       /* physical address */
+    phdr.p_filesz = elf_code->size + elf_data->size; /* size in file */
+    phdr.p_memsz = elf_code->size + elf_data->size;  /* size in memory */
+    phdr.p_flags = 7;                                /* flags */
+    phdr.p_align = 4;                                /* alignment */
+    elf_write_blk(elf_header, &phdr, sizeof(elf32_phdr_t));
 }
 
 void elf_generate_sections()
@@ -109,97 +193,129 @@ void elf_generate_sections()
     elf_write_byte(elf_section, 0);
 
     /* section header table */
+    elf32_shdr_t shdr;
+    int ofs = elf_header_len;
 
+    /*
+     * The following table uses the text section header as an example
+     * to explain the ELF32 section header.
+     *
+     *    |  Section       |                                                 |
+     *  & |  Header bytes  | Explanation                                     |
+     * ---+----------------+-------------------------------------------------+
+     *    | 0b  00  00  00 | sh_name: Name of the section. Giving the        |
+     *    |                |          location of a null-terminated string.  |
+     *    | 01  00  00  00 | sh_type: Type of the section's contents         |
+     *    |                |          and semantics.                         |
+     *    |                |          1 -> holds the program-defined         |
+     *    |                |               information                       |
+     *    | 07  00  00  00 | sh_flags: Miscellaneous attributes.             |
+     *    |                |           0x1 -> writable, 0x2 -> allocatable   |
+     *    |                |           0x4 -> executable.                    |
+     *    | 54  00  01  00 | sh_addr: Starting address of the section        |
+     *    |                |          in the memory image of a process.      |
+     *    | 54  00  00  00 | sh_offset: Offset of the section in the file.   |
+     *    | 0b  30  03  00 | sh_size: Size of the section.                   |
+     *    | 00  00  00  00 | sh_link: Section header table index link.       |
+     *    | 00  00  00  00 | sh_info: Extra information.                     |
+     *    | 04  00  00  00 | sh_addralign: Address alignment constraints.    |
+     *    | 00  00  00  00 | sh_entsize: Size of each entry.                 |
+     * ---+----------------+-------------------------------------------------+
+     *    |                |                                                 |
+     */
     /* NULL section */
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
+    shdr.sh_name = 0;
+    shdr.sh_type = 0;
+    shdr.sh_flags = 0;
+    shdr.sh_addr = 0;
+    shdr.sh_offset = 0;
+    shdr.sh_size = 0;
+    shdr.sh_link = 0;
+    shdr.sh_info = 0;
+    shdr.sh_addralign = 0;
+    shdr.sh_entsize = 0;
+    elf_write_blk(elf_section, &shdr, sizeof(elf32_shdr_t));
 
     /* .text */
-    elf_write_int(elf_section, 0xb);
-    elf_write_int(elf_section, 1);
-    elf_write_int(elf_section, 7);
-    elf_write_int(elf_section, ELF_START + elf_header_len);
-    elf_write_int(elf_section, elf_header_len);
-    elf_write_int(elf_section, elf_code->size);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 4);
-    elf_write_int(elf_section, 0);
+    shdr.sh_name = 0xb;
+    shdr.sh_type = 1;
+    shdr.sh_flags = 7;
+    shdr.sh_addr = ELF_START + elf_header_len;
+    shdr.sh_offset = ofs;
+    shdr.sh_size = elf_code->size;
+    shdr.sh_link = 0;
+    shdr.sh_info = 0;
+    shdr.sh_addralign = 4;
+    shdr.sh_entsize = 0;
+    elf_write_blk(elf_section, &shdr, sizeof(elf32_shdr_t));
+    ofs += elf_code->size;
 
     /* .data */
-    elf_write_int(elf_section, 0x11);
-    elf_write_int(elf_section, 1);
-    elf_write_int(elf_section, 3);
-    elf_write_int(elf_section, elf_code_start + elf_code->size);
-    elf_write_int(elf_section, elf_header_len + elf_code->size);
-    elf_write_int(elf_section, elf_data->size);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 4);
-    elf_write_int(elf_section, 0);
+    shdr.sh_name = 0x11;
+    shdr.sh_type = 1;
+    shdr.sh_flags = 3;
+    shdr.sh_addr = elf_code_start + elf_code->size;
+    shdr.sh_offset = ofs;
+    shdr.sh_size = elf_data->size;
+    shdr.sh_link = 0;
+    shdr.sh_info = 0;
+    shdr.sh_addralign = 4;
+    shdr.sh_entsize = 0;
+    elf_write_blk(elf_section, &shdr, sizeof(elf32_shdr_t));
+    ofs += elf_data->size;
 
     /* .symtab */
-    elf_write_int(elf_section, 0x17);
-    elf_write_int(elf_section, 2);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section,
-                  elf_header_len + elf_code->size + elf_data->size);
-    elf_write_int(elf_section, elf_symtab->size); /* size */
-    elf_write_int(elf_section, 4);
-    elf_write_int(elf_section, elf_symbol_index);
-    elf_write_int(elf_section, 4);
-    elf_write_int(elf_section, 16);
+    shdr.sh_name = 0x17;
+    shdr.sh_type = 2;
+    shdr.sh_flags = 0;
+    shdr.sh_addr = 0;
+    shdr.sh_offset = ofs;
+    shdr.sh_size = elf_symtab->size;
+    shdr.sh_link = 4;
+    shdr.sh_info = elf_symbol_index;
+    shdr.sh_addralign = 4;
+    shdr.sh_entsize = 16;
+    elf_write_blk(elf_section, &shdr, sizeof(elf32_shdr_t));
+    ofs += elf_symtab->size;
 
     /* .strtab */
-    elf_write_int(elf_section, 0x1f);
-    elf_write_int(elf_section, 3);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, elf_header_len + elf_code->size +
-                                   elf_data->size + elf_symtab->size);
-    elf_write_int(elf_section, elf_strtab->size); /* size */
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 1);
-    elf_write_int(elf_section, 0);
+    shdr.sh_name = 0x1f;
+    shdr.sh_type = 3;
+    shdr.sh_flags = 0;
+    shdr.sh_addr = 0;
+    shdr.sh_offset = ofs;
+    shdr.sh_size = elf_strtab->size;
+    shdr.sh_link = 0;
+    shdr.sh_info = 0;
+    shdr.sh_addralign = 1;
+    shdr.sh_entsize = 0;
+    elf_write_blk(elf_section, &shdr, sizeof(elf32_shdr_t));
+    ofs += elf_strtab->size;
 
     /* .shstr */
-    elf_write_int(elf_section, 1);
-    elf_write_int(elf_section, 3);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, elf_header_len + elf_code->size +
-                                   elf_data->size + elf_symtab->size +
-                                   elf_strtab->size);
-    elf_write_int(elf_section, 39);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 0);
-    elf_write_int(elf_section, 1);
-    elf_write_int(elf_section, 0);
+    shdr.sh_name = 1;
+    shdr.sh_type = 3;
+    shdr.sh_flags = 0;
+    shdr.sh_addr = 0;
+    shdr.sh_offset = ofs;
+    shdr.sh_size = 39;
+    shdr.sh_link = 0;
+    shdr.sh_info = 0;
+    shdr.sh_addralign = 1;
+    shdr.sh_entsize = 0;
+    elf_write_blk(elf_section, &shdr, sizeof(elf32_shdr_t));
 }
 
 void elf_align()
 {
-    int remainder = elf_data->size & 3;
-    if (remainder)
-        elf_data->size += (4 - remainder);
+    while (elf_data->size & 3)
+        elf_write_byte(elf_data, 0);
 
-    remainder = elf_symtab->size & 3;
-    if (remainder)
-        elf_symtab->size += (4 - remainder);
+    while (elf_symtab->size & 3)
+        elf_write_byte(elf_symtab, 0);
 
-    remainder = elf_strtab->size & 3;
-    if (remainder)
-        elf_strtab->size += (4 - remainder);
+    while (elf_strtab->size & 3)
+        elf_write_byte(elf_strtab, 0);
 }
 
 void elf_add_symbol(char *symbol, int pc)

--- a/src/elf.c
+++ b/src/elf.c
@@ -8,245 +8,214 @@
 /* ELF file manipulation */
 
 int elf_symbol_index;
-int elf_symtab_index;
-int elf_strtab_index;
-int elf_section_index;
 
-void elf_write_section_str(char *vals, int len)
+void elf_write_str(strbuf_t *elf_array, char *vals)
 {
-    for (int i = 0; i < len; i++)
-        elf_section[elf_section_index++] = vals[i];
+    /*
+     * Note that strbuf_puts() does not push the null character.
+     *
+     * If necessary, use elf_write_byte() to append the null character
+     * after calling strbuf_puts().
+     */
+    strbuf_puts(elf_array, vals);
 }
 
-void elf_write_data_str(char *vals, int len)
+void elf_write_byte(strbuf_t *elf_array, int val)
 {
-    for (int i = 0; i < len; i++)
-        elf_data[elf_data_idx++] = vals[i];
-}
-
-void elf_write_header_byte(int val)
-{
-    elf_header[elf_header_idx++] = val;
-}
-
-void elf_write_section_byte(char val)
-{
-    elf_section[elf_section_index++] = val;
+    strbuf_putc(elf_array, val);
 }
 
 char e_extract_byte(int v, int b)
 {
-    return (v >> (b * 8)) & 0xFF;
+    return (v >> (b << 3)) & 0xFF;
 }
 
-int elf_write_int(char *buf, int index, int val)
+void elf_write_int(strbuf_t *elf_array, int val)
 {
     for (int i = 0; i < 4; i++)
-        buf[index++] = e_extract_byte(val, i);
-    return index;
-}
-
-void elf_write_header_int(int val)
-{
-    elf_header_idx = elf_write_int(elf_header, elf_header_idx, val);
-}
-
-void elf_write_section_int(int val)
-{
-    elf_section_index = elf_write_int(elf_section, elf_section_index, val);
-}
-
-void elf_write_symbol_int(int val)
-{
-    elf_symtab_index = elf_write_int(elf_symtab, elf_symtab_index, val);
-}
-
-void elf_write_code_int(int val)
-{
-    elf_code_idx = elf_write_int(elf_code, elf_code_idx, val);
+        strbuf_putc(elf_array, e_extract_byte(val, i));
 }
 
 void elf_generate_header()
 {
     /* ELF header */
-    elf_write_header_int(0x464c457f); /* Magic: 0x7F followed by ELF */
-    elf_write_header_byte(1);         /* 32-bit */
-    elf_write_header_byte(1);         /* little-endian */
-    elf_write_header_byte(1);         /* EI_VERSION */
-    elf_write_header_byte(0);         /* System V */
-    elf_write_header_int(0);          /* EI_ABIVERSION */
-    elf_write_header_int(0);          /* EI_PAD: unused */
-    elf_write_header_byte(2);         /* ET_EXEC */
-    elf_write_header_byte(0);
-    elf_write_header_byte(ELF_MACHINE);
-    elf_write_header_byte(0);
-    elf_write_header_int(1);                          /* ELF version */
-    elf_write_header_int(ELF_START + elf_header_len); /* entry point */
-    elf_write_header_int(0x34); /* program header offset */
-    elf_write_header_int(elf_header_len + elf_code_idx + elf_data_idx + 39 +
-                         elf_symtab_index +
-                         elf_strtab_index); /* section header offset */
+    elf_write_int(elf_header, 0x464c457f); /* Magic: 0x7F followed by ELF */
+    elf_write_byte(elf_header, 1);         /* 32-bit */
+    elf_write_byte(elf_header, 1);         /* little-endian */
+    elf_write_byte(elf_header, 1);         /* EI_VERSION */
+    elf_write_byte(elf_header, 0);         /* System V */
+    elf_write_int(elf_header, 0);          /* EI_ABIVERSION */
+    elf_write_int(elf_header, 0);          /* EI_PAD: unused */
+    elf_write_byte(elf_header, 2);         /* ET_EXEC */
+    elf_write_byte(elf_header, 0);
+    elf_write_byte(elf_header, ELF_MACHINE);
+    elf_write_byte(elf_header, 0);
+    elf_write_int(elf_header, 1);                          /* ELF version */
+    elf_write_int(elf_header, ELF_START + elf_header_len); /* entry point */
+    elf_write_int(elf_header, 0x34); /* program header offset */
+    elf_write_int(elf_header, elf_header_len + elf_code->size + elf_data->size +
+                                  39 + elf_symtab->size +
+                                  elf_strtab->size); /* section header offset */
     /* flags */
-    elf_write_header_int(ELF_FLAGS);
-    elf_write_header_byte(0x34); /* header size */
-    elf_write_header_byte(0);
-    elf_write_header_byte(0x20); /* program header size */
-    elf_write_header_byte(0);
-    elf_write_header_byte(1); /* number of program headers */
-    elf_write_header_byte(0);
-    elf_write_header_byte(0x28); /* section header size */
-    elf_write_header_byte(0);
-    elf_write_header_byte(6); /* number of sections */
-    elf_write_header_byte(0);
-    elf_write_header_byte(5); /* section index with names */
-    elf_write_header_byte(0);
+    elf_write_int(elf_header, ELF_FLAGS);
+    elf_write_byte(elf_header, 0x34); /* header size */
+    elf_write_byte(elf_header, 0);
+    elf_write_byte(elf_header, 0x20); /* program header size */
+    elf_write_byte(elf_header, 0);
+    elf_write_byte(elf_header, 1); /* number of program headers */
+    elf_write_byte(elf_header, 0);
+    elf_write_byte(elf_header, 0x28); /* section header size */
+    elf_write_byte(elf_header, 0);
+    elf_write_byte(elf_header, 6); /* number of sections */
+    elf_write_byte(elf_header, 0);
+    elf_write_byte(elf_header, 5); /* section index with names */
+    elf_write_byte(elf_header, 0);
 
     /* program header - code and data combined */
-    elf_write_header_int(1);                           /* PT_LOAD */
-    elf_write_header_int(elf_header_len);              /* offset of segment */
-    elf_write_header_int(ELF_START + elf_header_len);  /* virtual address */
-    elf_write_header_int(ELF_START + elf_header_len);  /* physical address */
-    elf_write_header_int(elf_code_idx + elf_data_idx); /* size in file */
-    elf_write_header_int(elf_code_idx + elf_data_idx); /* size in memory */
-    elf_write_header_int(7);                           /* flags */
-    elf_write_header_int(4);                           /* alignment */
+    elf_write_int(elf_header, 1);              /* PT_LOAD */
+    elf_write_int(elf_header, elf_header_len); /* offset of segment */
+    elf_write_int(elf_header, ELF_START + elf_header_len); /* virtual address */
+    elf_write_int(elf_header,
+                  ELF_START + elf_header_len); /* physical address */
+    elf_write_int(elf_header,
+                  elf_code->size + elf_data->size); /* size in file */
+    elf_write_int(elf_header,
+                  elf_code->size + elf_data->size); /* size in memory */
+    elf_write_int(elf_header, 7);                   /* flags */
+    elf_write_int(elf_header, 4);                   /* alignment */
 }
 
 void elf_generate_sections()
 {
     /* symtab section */
-    for (int b = 0; b < elf_symtab_index; b++)
-        elf_write_section_byte(elf_symtab[b]);
+    for (int b = 0; b < elf_symtab->size; b++)
+        elf_write_byte(elf_section, elf_symtab->elements[b]);
 
     /* strtab section */
-    for (int b = 0; b < elf_strtab_index; b++)
-        elf_write_section_byte(elf_strtab[b]);
+    for (int b = 0; b < elf_strtab->size; b++)
+        elf_write_byte(elf_section, elf_strtab->elements[b]);
 
     /* shstr section; len = 39 */
-    elf_write_section_byte(0);
-    elf_write_section_str(".shstrtab", 9);
-    elf_write_section_byte(0);
-    elf_write_section_str(".text", 5);
-    elf_write_section_byte(0);
-    elf_write_section_str(".data", 5);
-    elf_write_section_byte(0);
-    elf_write_section_str(".symtab", 7);
-    elf_write_section_byte(0);
-    elf_write_section_str(".strtab", 7);
-    elf_write_section_byte(0);
+    elf_write_byte(elf_section, 0);
+    elf_write_str(elf_section, ".shstrtab");
+    elf_write_byte(elf_section, 0);
+    elf_write_str(elf_section, ".text");
+    elf_write_byte(elf_section, 0);
+    elf_write_str(elf_section, ".data");
+    elf_write_byte(elf_section, 0);
+    elf_write_str(elf_section, ".symtab");
+    elf_write_byte(elf_section, 0);
+    elf_write_str(elf_section, ".strtab");
+    elf_write_byte(elf_section, 0);
 
     /* section header table */
 
     /* NULL section */
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
 
     /* .text */
-    elf_write_section_int(0xb);
-    elf_write_section_int(1);
-    elf_write_section_int(7);
-    elf_write_section_int(ELF_START + elf_header_len);
-    elf_write_section_int(elf_header_len);
-    elf_write_section_int(elf_code_idx);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(4);
-    elf_write_section_int(0);
+    elf_write_int(elf_section, 0xb);
+    elf_write_int(elf_section, 1);
+    elf_write_int(elf_section, 7);
+    elf_write_int(elf_section, ELF_START + elf_header_len);
+    elf_write_int(elf_section, elf_header_len);
+    elf_write_int(elf_section, elf_code->size);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 4);
+    elf_write_int(elf_section, 0);
 
     /* .data */
-    elf_write_section_int(0x11);
-    elf_write_section_int(1);
-    elf_write_section_int(3);
-    elf_write_section_int(elf_code_start + elf_code_idx);
-    elf_write_section_int(elf_header_len + elf_code_idx);
-    elf_write_section_int(elf_data_idx);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(4);
-    elf_write_section_int(0);
+    elf_write_int(elf_section, 0x11);
+    elf_write_int(elf_section, 1);
+    elf_write_int(elf_section, 3);
+    elf_write_int(elf_section, elf_code_start + elf_code->size);
+    elf_write_int(elf_section, elf_header_len + elf_code->size);
+    elf_write_int(elf_section, elf_data->size);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 4);
+    elf_write_int(elf_section, 0);
 
     /* .symtab */
-    elf_write_section_int(0x17);
-    elf_write_section_int(2);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(elf_header_len + elf_code_idx + elf_data_idx);
-    elf_write_section_int(elf_symtab_index); /* size */
-    elf_write_section_int(4);
-    elf_write_section_int(elf_symbol_index);
-    elf_write_section_int(4);
-    elf_write_section_int(16);
+    elf_write_int(elf_section, 0x17);
+    elf_write_int(elf_section, 2);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section,
+                  elf_header_len + elf_code->size + elf_data->size);
+    elf_write_int(elf_section, elf_symtab->size); /* size */
+    elf_write_int(elf_section, 4);
+    elf_write_int(elf_section, elf_symbol_index);
+    elf_write_int(elf_section, 4);
+    elf_write_int(elf_section, 16);
 
     /* .strtab */
-    elf_write_section_int(0x1f);
-    elf_write_section_int(3);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(elf_header_len + elf_code_idx + elf_data_idx +
-                          elf_symtab_index);
-    elf_write_section_int(elf_strtab_index); /* size */
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(1);
-    elf_write_section_int(0);
+    elf_write_int(elf_section, 0x1f);
+    elf_write_int(elf_section, 3);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, elf_header_len + elf_code->size +
+                                   elf_data->size + elf_symtab->size);
+    elf_write_int(elf_section, elf_strtab->size); /* size */
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 1);
+    elf_write_int(elf_section, 0);
 
     /* .shstr */
-    elf_write_section_int(1);
-    elf_write_section_int(3);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(elf_header_len + elf_code_idx + elf_data_idx +
-                          elf_symtab_index + elf_strtab_index);
-    elf_write_section_int(39);
-    elf_write_section_int(0);
-    elf_write_section_int(0);
-    elf_write_section_int(1);
-    elf_write_section_int(0);
+    elf_write_int(elf_section, 1);
+    elf_write_int(elf_section, 3);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, elf_header_len + elf_code->size +
+                                   elf_data->size + elf_symtab->size +
+                                   elf_strtab->size);
+    elf_write_int(elf_section, 39);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 0);
+    elf_write_int(elf_section, 1);
+    elf_write_int(elf_section, 0);
 }
 
 void elf_align()
 {
-    int remainder = elf_data_idx & 3;
+    int remainder = elf_data->size & 3;
     if (remainder)
-        elf_data_idx += (4 - remainder);
+        elf_data->size += (4 - remainder);
 
-    remainder = elf_symtab_index & 3;
+    remainder = elf_symtab->size & 3;
     if (remainder)
-        elf_symtab_index += (4 - remainder);
+        elf_symtab->size += (4 - remainder);
 
-    remainder = elf_strtab_index & 3;
+    remainder = elf_strtab->size & 3;
     if (remainder)
-        elf_strtab_index += (4 - remainder);
+        elf_strtab->size += (4 - remainder);
 }
 
-void elf_add_symbol(char *symbol, int len, int pc)
+void elf_add_symbol(char *symbol, int pc)
 {
-    elf_write_symbol_int(elf_strtab_index);
-    elf_write_symbol_int(pc);
-    elf_write_symbol_int(0);
-    elf_write_symbol_int(pc == 0 ? 0 : 1 << 16);
+    elf_write_int(elf_symtab, elf_strtab->size);
+    elf_write_int(elf_symtab, pc);
+    elf_write_int(elf_symtab, 0);
+    elf_write_int(elf_symtab, pc == 0 ? 0 : 1 << 16);
 
-    strncpy(elf_strtab + elf_strtab_index, symbol, len);
-    elf_strtab_index += len;
-    elf_strtab[elf_strtab_index++] = 0;
+    elf_write_str(elf_strtab, symbol);
+    elf_write_byte(elf_strtab, 0);
     elf_symbol_index++;
 }
 
 void elf_generate(char *outfile)
 {
-    elf_symbol_index = 0;
-    elf_symtab_index = 0;
-    elf_strtab_index = 0;
-    elf_section_index = 0;
-
     elf_align();
     elf_generate_header();
     elf_generate_sections();
@@ -255,13 +224,13 @@ void elf_generate(char *outfile)
         outfile = "a.out";
 
     FILE *fp = fopen(outfile, "wb");
-    for (int i = 0; i < elf_header_idx; i++)
-        fputc(elf_header[i], fp);
-    for (int i = 0; i < elf_code_idx; i++)
-        fputc(elf_code[i], fp);
-    for (int i = 0; i < elf_data_idx; i++)
-        fputc(elf_data[i], fp);
-    for (int i = 0; i < elf_section_index; i++)
-        fputc(elf_section[i], fp);
+    for (int i = 0; i < elf_header->size; i++)
+        fputc(elf_header->elements[i], fp);
+    for (int i = 0; i < elf_code->size; i++)
+        fputc(elf_code->elements[i], fp);
+    for (int i = 0; i < elf_data->size; i++)
+        fputc(elf_data->elements[i], fp);
+    for (int i = 0; i < elf_section->size; i++)
+        fputc(elf_section->elements[i], fp);
     fclose(fp);
 }

--- a/src/globals.c
+++ b/src/globals.c
@@ -69,19 +69,15 @@ strbuf_t *SOURCE;
 hashmap_t *INCLUSION_MAP;
 
 /* ELF sections */
-
-char *elf_code;
-int elf_code_idx = 0;
-char *elf_data;
-int elf_data_idx = 0;
-char *elf_header;
-int elf_header_idx = 0;
+strbuf_t *elf_code;
+strbuf_t *elf_data;
+strbuf_t *elf_header;
+strbuf_t *elf_symtab;
+strbuf_t *elf_strtab;
+strbuf_t *elf_section;
 int elf_header_len = 0x54; /* ELF fixed: 0x34 + 1 * 0x20 */
 int elf_code_start;
 int elf_data_start;
-char *elf_symtab;
-char *elf_strtab;
-char *elf_section;
 
 /**
  * arena_block_create() - Creates a new arena block with given capacity.
@@ -1003,12 +999,12 @@ void global_init()
     ALIASES_MAP = hashmap_create(MAX_ALIASES);
     CONSTANTS_MAP = hashmap_create(MAX_CONSTANTS);
 
-    elf_code = malloc(MAX_CODE);
-    elf_data = malloc(MAX_DATA);
-    elf_header = malloc(MAX_HEADER);
-    elf_symtab = malloc(MAX_SYMTAB);
-    elf_strtab = malloc(MAX_STRTAB);
-    elf_section = malloc(MAX_SECTION);
+    elf_code = strbuf_create(MAX_CODE);
+    elf_data = strbuf_create(MAX_DATA);
+    elf_header = strbuf_create(MAX_HEADER);
+    elf_symtab = strbuf_create(MAX_SYMTAB);
+    elf_strtab = strbuf_create(MAX_STRTAB);
+    elf_section = strbuf_create(MAX_SECTION);
 }
 
 void global_release()
@@ -1031,12 +1027,12 @@ void global_release()
     hashmap_free(ALIASES_MAP);
     hashmap_free(CONSTANTS_MAP);
 
-    free(elf_code);
-    free(elf_data);
-    free(elf_header);
-    free(elf_symtab);
-    free(elf_strtab);
-    free(elf_section);
+    strbuf_free(elf_code);
+    strbuf_free(elf_data);
+    strbuf_free(elf_header);
+    strbuf_free(elf_symtab);
+    strbuf_free(elf_strtab);
+    strbuf_free(elf_section);
 }
 
 void error(char *msg)

--- a/src/globals.c
+++ b/src/globals.c
@@ -64,7 +64,7 @@ int elf_offset = 0;
 
 regfile_t REGS[REG_CNT];
 
-source_t *SOURCE;
+strbuf_t *SOURCE;
 
 hashmap_t *INCLUSION_MAP;
 
@@ -905,9 +905,9 @@ void add_insn(block_t *block,
     bb->insn_list.tail = n;
 }
 
-source_t *source_create(int init_capacity)
+strbuf_t *strbuf_create(int init_capacity)
 {
-    source_t *array = malloc(sizeof(source_t));
+    strbuf_t *array = malloc(sizeof(strbuf_t));
     if (!array)
         return NULL;
 
@@ -922,7 +922,7 @@ source_t *source_create(int init_capacity)
     return array;
 }
 
-bool source_extend(source_t *src, int len)
+bool strbuf_extend(strbuf_t *src, int len)
 {
     int new_size = src->size + len;
 
@@ -947,9 +947,9 @@ bool source_extend(source_t *src, int len)
     return true;
 }
 
-bool source_push(source_t *src, char value)
+bool strbuf_putc(strbuf_t *src, char value)
 {
-    if (!source_extend(src, 1))
+    if (!strbuf_extend(src, 1))
         return false;
 
     src->elements[src->size] = value;
@@ -958,11 +958,11 @@ bool source_push(source_t *src, char value)
     return true;
 }
 
-bool source_push_str(source_t *src, char *value)
+bool strbuf_puts(strbuf_t *src, char *value)
 {
     int len = strlen(value);
 
-    if (!source_extend(src, len))
+    if (!strbuf_extend(src, len))
         return false;
 
     strncpy(src->elements + src->size, value, len);
@@ -971,7 +971,7 @@ bool source_push_str(source_t *src, char *value)
     return true;
 }
 
-void source_free(source_t *src)
+void strbuf_free(strbuf_t *src)
 {
     if (!src)
         return;
@@ -998,7 +998,7 @@ void global_init()
     INSN_ARENA = arena_init(DEFAULT_ARENA_SIZE);
     BB_ARENA = arena_init(DEFAULT_ARENA_SIZE);
     PH2_IR_FLATTEN = malloc(MAX_IR_INSTR * sizeof(ph2_ir_t *));
-    SOURCE = source_create(MAX_SOURCE);
+    SOURCE = strbuf_create(MAX_SOURCE);
     INCLUSION_MAP = hashmap_create(DEFAULT_INCLUSIONS_SIZE);
     ALIASES_MAP = hashmap_create(MAX_ALIASES);
     CONSTANTS_MAP = hashmap_create(MAX_CONSTANTS);
@@ -1026,7 +1026,7 @@ void global_release()
     arena_free(INSN_ARENA);
     arena_free(BB_ARENA);
     free(PH2_IR_FLATTEN);
-    source_free(SOURCE);
+    strbuf_free(SOURCE);
     hashmap_free(INCLUSION_MAP);
     hashmap_free(ALIASES_MAP);
     hashmap_free(CONSTANTS_MAP);

--- a/src/parser.c
+++ b/src/parser.c
@@ -3422,7 +3422,7 @@ void load_source_file(char *file)
             snprintf(path + c + 1, inclusion_path_len, "%s", buffer + 10);
             load_source_file(path);
         } else {
-            source_push_str(SOURCE, buffer);
+            strbuf_puts(SOURCE, buffer);
         }
     }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -57,10 +57,11 @@ var_t *opstack_pop()
 
 void read_expr(block_t *parent, basic_block_t **bb);
 
-int write_symbol(char *data, int len)
+int write_symbol(char *data)
 {
-    int startLen = elf_data_idx;
-    elf_write_data_str(data, len);
+    int startLen = elf_data->size;
+    elf_write_str(elf_data, data);
+    elf_write_byte(elf_data, 0);
     return startLen;
 }
 
@@ -617,7 +618,7 @@ void read_literal_param(block_t *parent, basic_block_t *bb)
     char literal[MAX_TOKEN_LEN];
 
     lex_ident(T_string, literal);
-    int index = write_symbol(literal, strlen(literal) + 1);
+    int index = write_symbol(literal);
 
     ph1_ir_t *ph1_ir = add_ph1_ir(OP_load_data_address);
     var_t *vd = require_var(parent);
@@ -3365,7 +3366,7 @@ void parse_internal()
     type->size = 1;
 
     add_block(NULL, NULL, NULL); /* global block */
-    elf_add_symbol("", 0, 0);    /* undef symbol */
+    elf_add_symbol("", 0);       /* undef symbol */
 
     /* architecture defines */
     add_alias(ARCH_PREDEFINED, "1");

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -145,7 +145,7 @@ void cfg_flatten()
 
 void emit(int code)
 {
-    elf_write_code_int(code);
+    elf_write_int(elf_code, code);
 }
 
 void emit_ph2_ir(ph2_ir_t *ph2_ir)
@@ -236,14 +236,14 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
         emit(__addi(__t0, __t0, rv_lo(ofs)));
         emit(__beq(rs1, __zero, 8));
         emit(__jalr(__zero, __t0, 0));
-        emit(__jal(__zero, ph2_ir->else_bb->elf_offset - elf_code_idx));
+        emit(__jal(__zero, ph2_ir->else_bb->elf_offset - elf_code->size));
         return;
     case OP_jump:
-        emit(__jal(__zero, ph2_ir->next_bb->elf_offset - elf_code_idx));
+        emit(__jal(__zero, ph2_ir->next_bb->elf_offset - elf_code->size));
         return;
     case OP_call:
         func = find_func(ph2_ir->func_name);
-        emit(__jal(__ra, func->bbs->elf_offset - elf_code_idx));
+        emit(__jal(__ra, func->bbs->elf_offset - elf_code->size));
         return;
     case OP_load_data_address:
         emit(__lui(rd, rv_hi(elf_data_start + ph2_ir->src0)));
@@ -411,7 +411,7 @@ void code_generate()
     emit(__addi(__t0, __t0, rv_lo(GLOBAL_FUNC->stack_size)));
     emit(__sub(__sp, __sp, __t0));
     emit(__addi(__gp, __sp, 0));
-    emit(__jal(__ra, GLOBAL_FUNC->bbs->elf_offset - elf_code_idx));
+    emit(__jal(__ra, GLOBAL_FUNC->bbs->elf_offset - elf_code->size));
 
     /* exit */
     emit(__lui(__t0, rv_hi(GLOBAL_FUNC->stack_size)));
@@ -444,7 +444,7 @@ void code_generate()
     emit(__add(__t0, __gp, __t0));
     emit(__lw(__a0, __t0, 0));
     emit(__addi(__a1, __t0, 4));
-    emit(__jal(__zero, MAIN_BB->elf_offset - elf_code_idx));
+    emit(__jal(__zero, MAIN_BB->elf_offset - elf_code->size));
 
     for (int i = 0; i < ph2_ir_idx; i++) {
         ph2_ir = PH2_IR_FLATTEN[i];

--- a/tools/inliner.c
+++ b/tools/inliner.c
@@ -20,20 +20,20 @@
 #define MAX_LINE_LEN 200
 #define DEFAULT_SOURCE_SIZE 65536
 
-#define write_char(c) source_push(SOURCE, c)
-#define write_str(s) source_push_str(SOURCE, s)
+#define write_char(c) strbuf_putc(SOURCE, c)
+#define write_str(s) strbuf_puts(SOURCE, s)
 
 typedef struct {
     int size;
     int capacity;
     char *elements;
-} source_t;
+} strbuf_t;
 
-source_t *SOURCE;
+strbuf_t *SOURCE;
 
-source_t *source_create(int init_capacity)
+strbuf_t *strbuf_create(int init_capacity)
 {
-    source_t *array = malloc(sizeof(source_t));
+    strbuf_t *array = malloc(sizeof(strbuf_t));
     if (!array)
         return NULL;
 
@@ -48,7 +48,7 @@ source_t *source_create(int init_capacity)
     return array;
 }
 
-bool source_extend(source_t *src, int len)
+bool strbuf_extend(strbuf_t *src, int len)
 {
     int new_size = src->size + len;
 
@@ -73,9 +73,9 @@ bool source_extend(source_t *src, int len)
     return true;
 }
 
-bool source_push(source_t *src, char value)
+bool strbuf_putc(strbuf_t *src, char value)
 {
-    if (!source_extend(src, 1))
+    if (!strbuf_extend(src, 1))
         return false;
 
     src->elements[src->size] = value;
@@ -84,11 +84,11 @@ bool source_push(source_t *src, char value)
     return true;
 }
 
-bool source_push_str(source_t *src, char *value)
+bool strbuf_puts(strbuf_t *src, char *value)
 {
     int len = strlen(value);
 
-    if (!source_extend(src, len))
+    if (!strbuf_extend(src, len))
         return false;
 
     strncpy(src->elements + src->size, value, len);
@@ -97,7 +97,7 @@ bool source_push_str(source_t *src, char *value)
     return true;
 }
 
-void source_free(source_t *src)
+void strbuf_free(strbuf_t *src)
 {
     if (!src)
         return;
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    SOURCE = source_create(DEFAULT_SOURCE_SIZE);
+    SOURCE = strbuf_create(DEFAULT_SOURCE_SIZE);
 
     write_str("/* Created by tools/inliner - DO NOT EDIT. */\n");
 
@@ -167,14 +167,14 @@ int main(int argc, char *argv[])
      *   __c("}\n");
      */
     write_str("void __c(char *src) {\n");
-    write_str("    source_push_str(SOURCE, src);\n");
+    write_str("    strbuf_puts(SOURCE, src);\n");
     write_str("}\n");
 
     write_str("void libc_generate() {\n");
     load_from(argv[1]);
     write_str("}\n");
     save_to(argv[2]);
-    source_free(SOURCE);
+    strbuf_free(SOURCE);
 
     return 0;
 }


### PR DESCRIPTION
This pull request improves the ELF generation process to make it more reliable and readable. It includes the following changes:

### Rename `source_t` and its related functions
The structure is now renamed to `strbuf_t`, and it can be used to handle any variable-length character data, not just source code text.

The related functions are also renamed with the `strbuf_` prefix.

### Use `strbuf_t` for ELF arrays
The data type of the ELF-related arrays such as `elf_code`, `elf_data`, etc., is changed from `char *` to `strbuf_t *`. By `strbuf_t` and its functions, these arrays are automatically enlarged when their capacity becomes insufficient.

### Introduce ELF header structures
This pull request defines new structures `elf32_hdr_t`, `elf32_phdr_t` and `elf32_shdr_t` to represent the ELF header, program header and section header, respectively. By using their instances, the ELF header generation becomes more readable to understand. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the ELF generation process by renaming the `source_t` structure to `strbuf_t`, improving the handling of variable-length character data. It updates ELF-related arrays for automatic resizing and introduces new structures for ELF headers, enhancing code readability and maintainability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve renaming and restructuring, making the review process relatively simple.
</div>