### PR TITLE
Refine the build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,6 @@ CFLAGS := -O -g \
 BUILD_SESSION := .session.mk
 
 include mk/common.mk
-include mk/arm.mk
-include mk/riscv.mk
 -include $(BUILD_SESSION)
 
 STAGE0 := shecc
@@ -43,6 +41,7 @@ all: config bootstrap
 ifeq (,$(filter $(ARCH),$(ARCHS)))
 $(error Support ARM and RISC-V only. Select the target with "ARCH=arm" or "ARCH=riscv")
 endif
+include mk/$(ARCH).mk
 
 ifneq ("$(wildcard $(PWD)/config)","")
 TARGET_EXEC := $($(shell head -1 config | sed 's/.*: \([^ ]*\).*/\1/')_EXEC)


### PR DESCRIPTION
The top-level 'Makefile' unconditionally includes mk/{arm,riscv}.mk, and the shell substitutions inside those two files run immediately even when the active architecture is Arm.

That is why the "no qemu-riscv32 found" message appears during an Arm build. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request refines the build system by modifying the top-level Makefile to conditionally include architecture-specific files for ARM and RISC-V. This enhancement prevents unnecessary shell substitutions during builds for inactive architectures, improving the overall build process and error message clarity.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve modifications to the Makefile, making the review process relatively simple.
</div>