### PR TITLE
Refine the build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,6 @@ CFLAGS := -O -g \
 BUILD_SESSION := .session.mk
 
 include mk/common.mk
-include mk/arm.mk
-include mk/riscv.mk
 -include $(BUILD_SESSION)
 
 STAGE0 := shecc
@@ -43,11 +41,7 @@ all: config bootstrap
 ifeq (,$(filter $(ARCH),$(ARCHS)))
 $(error Support ARM and RISC-V only. Select the target with "ARCH=arm" or "ARCH=riscv")
 endif
-
-ifneq ("$(wildcard $(PWD)/config)","")
-TARGET_EXEC := $($(shell head -1 config | sed 's/.*: \([^ ]*\).*/\1/')_EXEC)
-endif
-export TARGET_EXEC
+include mk/$(ARCH).mk
 
 config:
 	$(Q)ln -s $(PWD)/$(SRCDIR)/$(ARCH)-codegen.c $(SRCDIR)/codegen.c

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ CFLAGS := -O -g \
 
 BUILD_SESSION := .session.mk
 
-include mk/common.mk
 -include $(BUILD_SESSION)
 
 STAGE0 := shecc
@@ -26,6 +25,7 @@ STAGE2 := shecc-stage2.elf
 OUT ?= out
 ARCHS = arm riscv
 ARCH ?= $(firstword $(ARCHS))
+HOST_ARCH = $(shell arch 2>/dev/null)
 SRCDIR := $(shell find src -type d)
 LIBDIR := $(shell find lib -type d)
 
@@ -42,12 +42,14 @@ ifeq (,$(filter $(ARCH),$(ARCHS)))
 $(error Support ARM and RISC-V only. Select the target with "ARCH=arm" or "ARCH=riscv")
 endif
 include mk/$(ARCH).mk
+include mk/common.mk
 
 config:
 	$(Q)ln -s $(PWD)/$(SRCDIR)/$(ARCH)-codegen.c $(SRCDIR)/codegen.c
-	$(call $(ARCH)-specific-defs) > $@
+	$(Q)$(PRINTF) $(ARCH_DEFS) > $@
 	$(VECHO) "Target machine code switch to %s\n" $(ARCH)
 	$(Q)$(MAKE) $(BUILD_SESSION) --silent
+	$(Q)$(CONFIG_CHECK_CMD)
 
 $(OUT)/tests/%.elf: tests/%.c $(OUT)/$(STAGE0)
 	$(VECHO) "  SHECC\t$@\n"
@@ -103,6 +105,7 @@ $(OUT)/$(STAGE0): $(OUT)/libc.inc $(OBJS)
 	$(Q)$(CC) $(OBJS) -o $@
 
 $(OUT)/$(STAGE1): $(OUT)/$(STAGE0)
+	$(Q)$(STAGE1_CHECK_CMD)
 	$(VECHO) "  SHECC\t$@\n"
 	$(Q)$(OUT)/$(STAGE0) --dump-ir -o $@ $(SRCDIR)/main.c > $(OUT)/shecc-stage1.log
 	$(Q)chmod a+x $@

--- a/mk/arm.mk
+++ b/mk/arm.mk
@@ -1,15 +1,15 @@
 ifeq ($(HOST_ARCH),armv7l) # detect ARMv7-A only and assume Linux-compatible
-    ARM_EXEC :=
+    TARGET_EXEC :=
 else
-    ARM_EXEC = qemu-arm
-    ARM_EXEC := $(shell which $(ARM_EXEC))
-    ifndef ARM_EXEC
+    TARGET_EXEC = qemu-arm
+    TARGET_EXEC := $(shell which $(TARGET_EXEC))
+    ifndef TARGET_EXEC
     $(warning "no qemu-arm found. Please check package installation")
     ARM_EXEC = echo WARN: unable to run
     endif
 endif
 
-export ARM_EXEC
+export TARGET_EXEC
 
 arm-specific-defs = \
     $(Q)$(PRINTF) \

--- a/mk/arm.mk
+++ b/mk/arm.mk
@@ -1,21 +1,9 @@
-ifeq ($(HOST_ARCH),armv7l) # detect ARMv7-A only and assume Linux-compatible
-    TARGET_EXEC :=
-else
-    TARGET_EXEC = qemu-arm
-    TARGET_EXEC := $(shell which $(TARGET_EXEC))
-    ifndef TARGET_EXEC
-    $(warning "no qemu-arm found. Please check package installation")
-    ARM_EXEC = echo WARN: unable to run
-    endif
-endif
-
-export TARGET_EXEC
-
-arm-specific-defs = \
-    $(Q)$(PRINTF) \
-        "/* target: ARM */\n$\
-        \#pragma once\n$\
-        \#define ARCH_PREDEFINED \"__arm__\" /* defined by GNU C and RealView */\n$\
-        \#define ELF_MACHINE 0x28 /* up to ARMv7/Aarch32 */\n$\
-        \#define ELF_FLAGS 0x5000200\n$\
-        "
+ARCH_NAME = armv7l
+ARCH_RUNNER = qemu-arm
+ARCH_DEFS = \
+    "/* target: ARM */\n$\
+    \#pragma once\n$\
+    \#define ARCH_PREDEFINED \"__arm__\" /* defined by GNU C and RealView */\n$\
+    \#define ELF_MACHINE 0x28 /* up to ARMv7/Aarch32 */\n$\
+    \#define ELF_FLAGS 0x5000200\n$\
+    "

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -5,8 +5,6 @@ else
     PRINTF = env printf
 endif
 
-HOST_ARCH = $(shell arch 2>/dev/null)
-
 # Control the build verbosity
 ifeq ("$(VERBOSE)","1")
     Q :=
@@ -23,3 +21,29 @@ PASS_COLOR = \e[32;01m
 NO_COLOR = \e[0m
 
 pass = $(PRINTF) "$(PASS_COLOR)$1 Passed$(NO_COLOR)\n"
+
+# Check the prerequisites
+PREREQ_LIST := dot jq
+TARGET_EXEC ?=
+ifneq ($(HOST_ARCH),$(ARCH_NAME))
+    # Add qemu to the list if the host and target architectures differ
+    PREREQ_LIST += $(ARCH_RUNNER)
+    ifeq ($(filter $(ARCH_RUNNER),$(notdir $(shell which $(ARCH_RUNNER)))),)
+        STAGE1_WARN_MSG := "Warning: failed to build the stage 1 and $\
+                               stage 2 compilers due to missing $(ARCH_RUNNER)\n"
+        STAGE1_CHECK_CMD := $(VECHO) $(STAGE1_WARN_MSG) && exit 1
+    endif
+
+    # Generate the path to the architecture-specific qemu
+    TARGET_EXEC = $(shell which $(ARCH_RUNNER))
+endif
+export TARGET_EXEC
+
+PREREQ_EXEC := $(shell which $(PREREQ_LIST))
+PREREQ_MISSING := $(filter-out $(notdir $(PREREQ_EXEC)),$(PREREQ_LIST))
+
+ifdef PREREQ_MISSING
+    CONFIG_WARN_MSG := "Warning: missing packages: $(PREREQ_MISSING)\n$\
+                            Warning: Please check package installation\n"
+    CONFIG_CHECK_CMD := $(VECHO) $(CONFIG_WARN_MSG)
+endif

--- a/mk/riscv.mk
+++ b/mk/riscv.mk
@@ -1,17 +1,10 @@
-TARGET_EXEC = qemu-riscv32
-TARGET_EXEC := $(shell which $(TARGET_EXEC))
-ifndef TARGET_EXEC
-$(warning "no qemu-riscv32 found. Please check package installation")
-TARGET_EXEC = echo WARN: unable to run
-endif
-
-export TARGET_EXEC
-
-riscv-specific-defs = \
-    $(Q)$(PRINTF) \
-        "/* target: RISCV */\n$\
-        \#pragma once\n$\
-        \#define ARCH_PREDEFINED \"__riscv\" /* Older versions of the GCC toolchain defined __riscv__ */\n$\
-        \#define ELF_MACHINE 0xf3\n$\
-        \#define ELF_FLAGS 0\n$\
-        "
+# Enforce the use qemu of by setting the ARCH_NAME variable to empty
+ARCH_NAME =
+ARCH_RUNNER = qemu-riscv32
+ARCH_DEFS = \
+    "/* target: RISCV */\n$\
+    \#pragma once\n$\
+    \#define ARCH_PREDEFINED \"__riscv\" /* Older versions of the GCC toolchain defined __riscv__ */\n$\
+    \#define ELF_MACHINE 0xf3\n$\
+    \#define ELF_FLAGS 0\n$\
+    "

--- a/mk/riscv.mk
+++ b/mk/riscv.mk
@@ -1,11 +1,11 @@
-RISCV_EXEC = qemu-riscv32
-RISCV_EXEC := $(shell which $(RISCV_EXEC))
-ifndef RISCV_EXEC
+TARGET_EXEC = qemu-riscv32
+TARGET_EXEC := $(shell which $(TARGET_EXEC))
+ifndef TARGET_EXEC
 $(warning "no qemu-riscv32 found. Please check package installation")
-RISCV_EXEC = echo WARN: unable to run
+TARGET_EXEC = echo WARN: unable to run
 endif
 
-export RISCV_EXEC
+export TARGET_EXEC
 
 riscv-specific-defs = \
     $(Q)$(PRINTF) \


### PR DESCRIPTION
This pull request resolves the following issues:

### Fix empty `TARGET_EXEC` variable
Previously, I noticed that the build system directly executed the stage1 compiler to build the stage2 compiler, instead of invoking `qemu-user`. This issue could be observed by running `make VERBOSE=1`
```diff
$ make VERBOSE=1
...
...
+out/shecc-stage1.elf -o out/shecc-stage2.elf src/main.c
...
```
That is, `TARGET_EXEC`, which stores the the name of an architecture-specific qemu executable, is left empty and not properly assigned.

Therefore, these changes fix it to ensure the build system invokes qemu as expected.
 
Close #44 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the build system by fixing the empty TARGET_EXEC variable issue, which caused build failures. It improves Makefiles for ARM and RISC-V architectures with prerequisite checks for necessary tools, ensuring a more reliable build process and correct invocation of qemu executables.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>