### PR TITLE
Support global string initialization

### DIFF
--- a/src/reg-alloc.c
+++ b/src/reg-alloc.c
@@ -283,8 +283,9 @@ void reg_alloc(void)
             }
             break;
         case OP_load_constant:
+        case OP_load_data_address:
             dest = prepare_dest(GLOBAL_FUNC->bbs, global_insn->rd, -1, -1);
-            ir = bb_add_ph2_ir(GLOBAL_FUNC->bbs, OP_load_constant);
+            ir = bb_add_ph2_ir(GLOBAL_FUNC->bbs, global_insn->opcode);
             ir->src0 = global_insn->rd->init_val;
             ir->dest = dest;
             break;

--- a/src/ssa.c
+++ b/src/ssa.c
@@ -880,11 +880,6 @@ void unwind_phi(void)
     free(args);
 }
 
-/*
- * The current cfonrt does not yet support string literal addressing, which
- * results in the omission of basic block visualization during the stage-1 and
- * stage-2 bootstrapping phases.
- */
 #ifdef __SHECC__
 #else
 void bb_dump_connection(FILE *fd,
@@ -896,13 +891,13 @@ void bb_dump_connection(FILE *fd,
 
     switch (type) {
     case NEXT:
-        str = &"%s_%p:s->%s_%p:n\n"[0];
+        str = "%s_%p:s->%s_%p:n\n";
         break;
     case THEN:
-        str = &"%s_%p:sw->%s_%p:n\n"[0];
+        str = "%s_%p:sw->%s_%p:n\n";
         break;
     case ELSE:
-        str = &"%s_%p:se->%s_%p:n\n"[0];
+        str = "%s_%p:se->%s_%p:n\n";
         break;
     default:
         abort();
@@ -911,20 +906,20 @@ void bb_dump_connection(FILE *fd,
     char *pred;
     void *pred_id;
     if (curr->insn_list.tail) {
-        pred = &"insn"[0];
+        pred = "insn";
         pred_id = curr->insn_list.tail;
     } else {
-        pred = &"pseudo"[0];
+        pred = "pseudo";
         pred_id = curr;
     }
 
     char *succ;
     void *succ_id;
     if (next->insn_list.tail) {
-        succ = &"insn"[0];
+        succ = "insn";
         succ_id = next->insn_list.head;
     } else {
-        succ = &"pseudo"[0];
+        succ = "pseudo";
         succ_id = next;
     }
 

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -1357,6 +1357,19 @@ int main()
 }
 EOF
 
+# global string initialization and modification
+try_output 0 "Hello World!Hallo World!" << EOF
+char *data = "Hello World!";
+
+int main(void)
+{
+    printf(data);
+    data[1] = 'a';
+    printf(data);
+    return 0;
+}
+EOF
+
 # global initialization with logical and equality operation
 try_ 4 << EOF
 int b1 = 1 && 1;


### PR DESCRIPTION
This patch supports global string initialization, and allows integer values to be used as address value of any pointer type. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances global string initialization by allowing integer values as address values for pointer types. Key modifications include parser updates for string literals, improved register allocation for data addresses, and SSA updates for better string formatting. New tests have been added to ensure the functionality works as intended.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>