### PR TITLE
Allow bootstrap without binfmt_misc QEMU support

### DIFF
--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -11,9 +11,9 @@ case "$1" in
     "0")
         readonly SHECC="$PWD/out/shecc" ;;
     "1")
-        readonly SHECC="$PWD/out/shecc-stage1.elf" ;;
+        readonly SHECC="$TARGET_EXEC $PWD/out/shecc-stage1.elf" ;;
     "2")
-        readonly SHECC="$PWD/out/shecc-stage2.elf" ;;
+        readonly SHECC="$TARGET_EXEC $PWD/out/shecc-stage2.elf" ;;
     *)
         echo "$1 is not a valid stage"
         exit 1 ;;
@@ -40,7 +40,7 @@ function try() {
     local tmp_in="$(mktemp --suffix .c)"
     local tmp_exe="$(mktemp)"
     echo "$input" > "$tmp_in"
-    "$SHECC" -o "$tmp_exe" "$tmp_in"
+    $SHECC -o "$tmp_exe" "$tmp_in"
     chmod +x $tmp_exe
 
     local output=''
@@ -93,7 +93,7 @@ function try_compile_error() {
     local tmp_in="$(mktemp --suffix .c)"
     local tmp_exe="$(mktemp)"
     echo "$input" > "$tmp_in"
-    "$SHECC" -o "$tmp_exe" "$tmp_in"
+    $SHECC -o "$tmp_exe" "$tmp_in"
     local exit_code=$?
 
     if [ 0 == $exit_code ]; then


### PR DESCRIPTION
When GNU/Linux lacks binfmt_misc configuration for QEMU Arm/RV32 binary recognition, bootstrap stages 1 and 2 fail due to incompatible binary formats. This change explicitly specifies QEMU wrappers to execute cross-compiled binaries during bootstrap. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request resolves an issue with the bootstrap process for QEMU on GNU/Linux by modifying the SHECC path in the driver script. These changes improve compatibility and prevent failures due to incompatible binary formats during the bootstrap stages.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>