### PR TITLE
Fix parsing to support uppercase 0X hex literals

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -295,7 +295,7 @@ int read_numeric_constant(char buffer[])
     int i = 0;
     int value = 0;
     while (buffer[i]) {
-        if (i == 1 && (buffer[i] == 'x')) { /* hexadecimal */
+        if (i == 1 && (buffer[i] | 32) == 'x') { /* hexadecimal */
             value = 0;
             i = 2;
             while (buffer[i]) {
@@ -784,7 +784,7 @@ void read_numeric_param(block_t *parent, basic_block_t *bb, int is_neg)
         i++;
     }
     if (token[0] == '0') {
-        if (token[1] == 'x') { /* hexdecimal */
+        if ((token[1] | 32) == 'x') { /* hexdecimal */
             i = 2;
             do {
                 c = token[i++];

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -1855,4 +1855,32 @@ int main(void)
 }
 EOF
 
+try_output 0 "2748 6719 105884 0" << EOF
+int main()
+{
+    int a = 0XABC;
+    int b = 0X1a3f;
+    int c = 0XDEaD + 0xBeEF;
+    int d = 0X0;
+    printf("%d %d %d %d", a, b, c, d);
+    return 0;
+}
+EOF
+
+try_compile_error << EOF
+int main()
+{
+    int x = 0X;
+    return 0;
+}
+EOF
+
+try_compile_error << EOF
+int main()
+{
+    int x = 0XGHI;
+    return 0;
+}
+EOF
+
 echo OK


### PR DESCRIPTION
Previously, literals with uppercase 0X prefix (e.g., "0XABC") were misparsed as invalid. This commit fixes that and improves compatibility with C99-style numeric constants.

- Removed incorrect inclusion of 'x' as a hex digit in is_hex()
- Updated is_numeric() to skip 0x/0X prefix when validating hex digits
- Adjusted read_numeric_constant() to consistently handle both 0x and 0X prefixes 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances numeric literal parsing by adding support for uppercase 0X hexadecimal prefixes, correcting previous misparsing issues. Modifications were made to the is_hex and is_numeric functions for better validation, and the read_numeric_constant function was updated for consistent handling of both prefix styles, improving C99 compatibility. New tests have been included to ensure the accuracy of these changes.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>