### PR TITLE
Fix potential segfault when reporting error

### DIFF
--- a/src/ssa.c
+++ b/src/ssa.c
@@ -697,7 +697,7 @@ void new_name(block_t *block, var_t **var)
 var_t *get_stack_top_subscript_var(var_t *var)
 {
     if (var->base->rename.stack_idx < 1)
-        error("Index is less than 1");
+        fatal("Index is less than 1");
 
     int sub = var->base->rename.stack[var->base->rename.stack_idx - 1];
     for (int i = 0; i < var->base->subscripts_idx; i++) {


### PR DESCRIPTION
When reaching to SSA phase, the `error` function would always cause segment fault due to the internal design, which is the source index is always going to be out of bound. In this patch, we instead use `fatal` function to avoid this issue. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a critical bug in the SSA phase by replacing the 'error' function with 'fatal', preventing segmentation faults from out-of-bounds indices. This change significantly enhances the stability of the code during execution.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>