### PR TITLE
Improve IR dumping information

### DIFF
--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -147,11 +147,10 @@ void cfg_flatten(void)
     elf_offset += 24;
 
     for (func = FUNC_LIST.head; func; func = func->next) {
-        ph2_ir_t *flatten_ir;
-
         /* reserve stack */
-        flatten_ir = add_ph2_ir(OP_define);
+        ph2_ir_t *flatten_ir = add_ph2_ir(OP_define);
         flatten_ir->src0 = func->stack_size;
+        strncpy(flatten_ir->func_name, func->return_def.var_name, MAX_VAR_LEN);
 
         for (basic_block_t *bb = func->bbs; bb; bb = bb->rpo_next) {
             bb->elf_offset = elf_offset;

--- a/src/riscv-codegen.c
+++ b/src/riscv-codegen.c
@@ -124,6 +124,7 @@ void cfg_flatten(void)
         /* reserve stack */
         ph2_ir_t *flatten_ir = add_ph2_ir(OP_define);
         flatten_ir->src0 = func->stack_size;
+        strncpy(flatten_ir->func_name, func->return_def.var_name, MAX_VAR_LEN);
 
         for (basic_block_t *bb = func->bbs; bb; bb = bb->rpo_next) {
             bb->elf_offset = elf_offset;

--- a/src/ssa.c
+++ b/src/ssa.c
@@ -991,7 +991,7 @@ void bb_dump(FILE *fd, func_t *func, basic_block_t *bb)
         printf("Warning: normal BB with condition\n");
 
     fprintf(fd, "subgraph cluster_%p {\n", bb);
-    fprintf(fd, "label=\"BasicBlock %p\"\n", bb);
+    fprintf(fd, "label=\"BasicBlock %p (%s)\"\n", bb, bb->bb_label_name);
 
     insn_t *insn = bb->insn_list.head;
     if (!insn)
@@ -1170,7 +1170,7 @@ void dump_cfg(char name[])
     for (func_t *func = FUNC_LIST.head; func; func = func->next) {
         func->visited++;
         fprintf(fd, "subgraph cluster_%p {\n", func);
-        fprintf(fd, "label=\"%p\"\n", func);
+        fprintf(fd, "label=\"%p (%s)\"\n", func, func->return_def.var_name);
         bb_dump(fd, func, func->bbs);
         fprintf(fd, "}\n");
     }


### PR DESCRIPTION
This patch adds naming to various member when dumping IR, e.g. function names to basic block clusters, basic block pseudo names to each basic blocks. Also, fixed phase 2 IR dumping not printing out the name of functions. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the IR processing by adding function names to basic block clusters and improving basic block labeling. The updates make the IR dumping process more informative and correct a previous oversight in phase 2 IR dumping.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve labeling improvements, making the review process relatively simple.
-->
</div>