### PR TITLE
Implement macro parameter substitution in statement contexts

### DIFF
--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -928,6 +928,49 @@ int main()
 }
 EOF
 
+# macro parameter substitution works in expression contexts
+try_ 15 << EOF
+#define ADD_PARAMS(a, b) ((a) + (b))
+int main()
+{
+    int x = 5, y = 10;
+    return ADD_PARAMS(x, y);
+}
+EOF
+
+# macro with assignment operators
+try_ 18 << EOF
+#define ASSIGN_MACRO(variable, val) \
+    variable = variable + val + 10
+int main()
+{
+    int x = 5;
+    ASSIGN_MACRO(x, 3);
+    return x;
+}
+EOF
+
+try_ 27 << EOF
+#define COMPOUND_ASSIGN(variable, val) \
+    variable += val + 10
+int main()
+{
+    int y = 10;
+    COMPOUND_ASSIGN(y, 7);
+    return y;
+}
+EOF
+
+try_ 42 << EOF
+#define SET_VAR(var, value) var = value
+int main()
+{
+    int z = 0;
+    SET_VAR(z, 42);
+    return z;
+}
+EOF
+
 try_output 0 "Wrapper: Hello World!" << EOF
 #define WRAPPER(...)         \
     do {                     \


### PR DESCRIPTION
This enables function-like macros with statement bodies that reference macro parameters.

Examples now supported:
- ASSIGN_MACRO(variable, val) → variable = variable + val + 10
- COMPOUND_ASSIGN(variable, val) → variable += val + 10
- SET_VAR(var, value) → var = value

Implementation uses find_macro_param_src_idx() with careful lexer  state management to safely substitute parameter values in statement  parsing contexts, matching existing expression context functionality.

Close #142 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the macro system by implementing parameter substitution in statement contexts and introducing new macros like ASSIGN_MACRO and COMPOUND_ASSIGN. Comprehensive tests have been added to ensure the functionality and robustness of these features.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>