### PR TITLE
Fix DU-chain memory management using arena alloc

### DIFF
--- a/src/ssa.c
+++ b/src/ssa.c
@@ -410,11 +410,7 @@ void build_rdf(void)
 
 void use_chain_add_tail(insn_t *i, var_t *var)
 {
-    use_chain_t *u = calloc(1, sizeof(use_chain_t));
-    if (!u) {
-        printf("calloc failed\n");
-        abort();
-    }
+    use_chain_t *u = arena_calloc(INSN_ARENA, 1, sizeof(use_chain_t));
 
     u->insn = i;
     if (!var->users_head)
@@ -439,7 +435,6 @@ void use_chain_delete(use_chain_t *u, var_t *var)
         var->users_tail = u->prev;
         u->prev->next = NULL;
     }
-    free(u);
 }
 
 void use_chain_build(void)


### PR DESCRIPTION
This commit migrates definition-use (DU) chain allocation from manual memory management to the arena allocator system. This change ensures consistent memory handling and prevents potential memory leaks.

The DU-chain memory is now automatically freed when INSN_ARENA is destroyed during global_release(), following shecc's established memory management patterns.

Close #160 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request improves memory management by replacing manual allocation with an arena allocator system, enhancing consistency and reducing memory leak risks. The DU-chain memory will be automatically released upon destruction of the INSN_ARENA, following best practices.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>