### PR TITLE
Fix off-by-one error in argument parsing

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
         else if (!strcmp(argv[i], "--no-libc"))
             libc = 0;
         else if (!strcmp(argv[i], "-o")) {
-            if (i < argc + 1) {
+            if (i + 1 < argc) {
                 out = argv[i + 1];
                 i++;
             } else


### PR DESCRIPTION
This commit prevents buffer overflow when -o lacks required filename. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a critical bug in the argument parsing logic, addressing an off-by-one error that could cause a buffer overflow with the '-o' option. The enhancement improves the application's robustness by ensuring correct behavior in edge cases.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>