### PR TITLE
Replace strcmp chains with hashmap lookups

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -1113,8 +1113,14 @@ void global_init(void)
     elf_section = strbuf_create(MAX_SECTION);
 }
 
+/* Forward declaration for lexer cleanup */
+void lexer_cleanup(void);
+
 void global_release(void)
 {
+    /* Cleanup lexer hashmaps */
+    lexer_cleanup();
+
     hashmap_free(MACROS_MAP);
     free(TYPES);
     arena_free(BLOCK_ARENA);


### PR DESCRIPTION
This commit modernizes lexer token recognition by utilizing existing hashmap infrastructure and arena allocation system for performance and consistency, resulting in O(n) → O(1) average case token lookup.