### PR TITLE
Prevent buffer overflow in type array allocation

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -19,7 +19,7 @@
 #define MAX_PARAMS 8
 #define MAX_LOCALS 1600
 #define MAX_FIELDS 64
-#define MAX_TYPES 64
+#define MAX_TYPES 128
 #define MAX_IR_INSTR 60000
 #define MAX_BB_PRED 128
 #define MAX_BB_DOM_SUCC 64

--- a/src/globals.c
+++ b/src/globals.c
@@ -721,6 +721,10 @@ int find_macro_param_src_idx(char *name, block_t *parent)
 
 type_t *add_type(void)
 {
+    if (types_idx >= MAX_TYPES) {
+        printf("Error: Maximum number of types (%d) exceeded\n", MAX_TYPES);
+        abort();
+    }
     return &TYPES[types_idx++];
 }
 


### PR DESCRIPTION
This commit adds bounds checking to add_type and increase MAX_TYPES to 128, fixing memory corruption during stage-1 compilation when typedef count exceeds limit.