### PR TITLE
Fix logical NOT operator crash in Arm codegen

### DIFF
--- a/src/arm-codegen.c
+++ b/src/arm-codegen.c
@@ -419,7 +419,7 @@ void emit_ph2_ir(ph2_ir_t *ph2_ir)
         emit(__eor_r(__AL, rd, rn, rm));
         return;
     case OP_log_not:
-        emit(__teq(rn));
+        emit(__cmp_i(__AL, rn, 0));
         emit(__mov_i(__NE, rd, 0));
         emit(__mov_i(__EQ, rd, 1));
         return;


### PR DESCRIPTION
This replaces malformed TEQ instruction with proper CMP instruction for OP_log_not. TEQ requires two operands but was only given one, causing compilation failures for expressions using the \! operator.

The fix uses CMP to compare the register with 0, followed by conditional MOV instructions to set the result correctly.