### PR TITLE
Convert int variables to bool type when possible

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -350,7 +350,7 @@ typedef struct var_list {
 struct var {
     type_t *type;
     char var_name[MAX_VAR_LEN];
-    int is_ptr;
+    int ptr_level;
     bool is_func;
     bool is_global;
     int array_size;
@@ -439,7 +439,7 @@ struct type {
 /* lvalue details */
 typedef struct {
     int size;
-    int is_ptr;
+    int ptr_level;
     bool is_func;
     bool is_reference;
     type_t *type;

--- a/src/globals.c
+++ b/src/globals.c
@@ -584,8 +584,8 @@ void hashmap_free(hashmap_t *map)
 
 /* options */
 
-int dump_ir = 0;
-int hard_mul_div = 0;
+bool dump_ir = false;
+bool hard_mul_div = false;
 
 /* Find the type by the given name.
  * @type_name: The name to be searched.
@@ -883,7 +883,7 @@ var_t *find_var(char *token, block_t *parent)
 int size_var(var_t *var)
 {
     int size;
-    if (var->is_ptr > 0 || var->is_func) {
+    if (var->ptr_level > 0 || var->is_func) {
         size = 4;
     } else {
         type_t *type = var->type;
@@ -1426,7 +1426,7 @@ void dump_bb_insn(func_t *func, basic_block_t *bb, bool *at_func_start)
             print_indent(1);
             printf("allocat %s", rd->type->type_name);
 
-            for (int i = 0; i < rd->is_ptr; i++)
+            for (int i = 0; i < rd->ptr_level; i++)
                 printf("*");
 
             printf(" %%%s", rd->var_name);
@@ -1636,7 +1636,7 @@ void dump_insn(void)
 
         printf("def %s", func->return_def.type->type_name);
 
-        for (int i = 0; i < func->return_def.is_ptr; i++)
+        for (int i = 0; i < func->return_def.ptr_level; i++)
             printf("*");
         printf(" @%s(", func->return_def.var_name);
 
@@ -1645,7 +1645,7 @@ void dump_insn(void)
                 printf(", ");
             printf("%s", func->param_defs[i].type->type_name);
 
-            for (int k = 0; k < func->param_defs[i].is_ptr; k++)
+            for (int k = 0; k < func->param_defs[i].ptr_level; k++)
                 printf("*");
             printf(" %%%s", func->param_defs[i].var_name);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -48,16 +48,16 @@
 
 int main(int argc, char *argv[])
 {
-    int libc = 1;
+    bool libc = true;
     char *out = NULL, *in = NULL;
 
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "--dump-ir"))
-            dump_ir = 1;
+            dump_ir = true;
         else if (!strcmp(argv[i], "+m"))
-            hard_mul_div = 1;
+            hard_mul_div = true;
         else if (!strcmp(argv[i], "--no-libc"))
-            libc = 0;
+            libc = false;
         else if (!strcmp(argv[i], "-o")) {
             if (i + 1 < argc) {
                 out = argv[i + 1];

--- a/src/riscv.c
+++ b/src/riscv.c
@@ -154,14 +154,14 @@ int rv_encode_S(rv_op op, rv_reg rs1, rv_reg rs2, int imm)
 
 int rv_encode_B(rv_op op, rv_reg rs1, rv_reg rs2, int imm)
 {
-    int sign = 0;
+    bool sign = false;
 
     /* 13 signed bits, with bit zero ignored */
     if (imm > 4095 || imm < -4096)
         error("Offset too large");
 
     if (imm < 0)
-        sign = 1;
+        sign = true;
 
     return op + (rs1 << 15) + (rs2 << 20) + rv_extract_bits(imm, 11, 11, 7, 7) +
            rv_extract_bits(imm, 1, 4, 8, 11) +
@@ -170,10 +170,10 @@ int rv_encode_B(rv_op op, rv_reg rs1, rv_reg rs2, int imm)
 
 int rv_encode_J(rv_op op, rv_reg rd, int imm)
 {
-    int sign = 0;
+    bool sign = false;
 
     if (imm < 0) {
-        sign = 1;
+        sign = true;
         imm = -imm;
         imm = (1 << 21) - imm;
     }

--- a/src/ssa.c
+++ b/src/ssa.c
@@ -2042,10 +2042,10 @@ int merge_live_in(var_t *live_out[], int live_out_idx, basic_block_t *bb)
     if (live_out_idx < 16) {
         /* For small sets, simple linear search is fast enough */
         for (int i = 0; i < bb->live_in_idx; i++) {
-            int found = 0;
+            bool found = false;
             for (int j = 0; j < live_out_idx; j++) {
                 if (live_out[j] == bb->live_in[i]) {
-                    found = 1;
+                    found = true;
                     break;
                 }
             }
@@ -2055,14 +2055,14 @@ int merge_live_in(var_t *live_out[], int live_out_idx, basic_block_t *bb)
     } else {
         /* For larger sets, check bounds and use optimized loop */
         for (int i = 0; i < bb->live_in_idx; i++) {
-            int found = 0;
+            bool found = false;
             var_t *var = bb->live_in[i];
             /* Unroll inner loop for better performance */
             int j;
             for (j = 0; j + 3 < live_out_idx; j += 4) {
                 if (live_out[j] == var || live_out[j + 1] == var ||
                     live_out[j + 2] == var || live_out[j + 3] == var) {
-                    found = 1;
+                    found = true;
                     break;
                 }
             }
@@ -2070,7 +2070,7 @@ int merge_live_in(var_t *live_out[], int live_out_idx, basic_block_t *bb)
             if (!found) {
                 for (; j < live_out_idx; j++) {
                     if (live_out[j] == var) {
-                        found = 1;
+                        found = true;
                         break;
                     }
                 }


### PR DESCRIPTION
The bool type (1 byte) provides memory efficiency over int (4 bytes) and gives semantic hints to the optimizer for boolean-specific optimizations.