### PR TITLE
Fix pointer aliasing bug in constant optimization

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -353,6 +353,7 @@ struct var {
     int ptr_level;
     bool is_func;
     bool is_global;
+    bool address_taken; /* true if variable address was taken (&var) */
     int array_size;
     int array_dim1, array_dim2; /* first/second dimension size for 2D arrays */
     int offset;   /* offset from stack or frame, index 0 is reserved */

--- a/src/globals.c
+++ b/src/globals.c
@@ -1089,6 +1089,14 @@ void add_insn(block_t *block,
     else
         n->str[0] = '\0';
 
+    /* Mark variables as address-taken to prevent incorrect constant
+     * optimization
+     */
+    if ((op == OP_address_of || op == OP_global_address_of) && rs1) {
+        rs1->address_taken = true;
+        rs1->is_const = false; /* disable constant optimization */
+    }
+
     if (!bb->insn_list.head)
         bb->insn_list.head = n;
     else


### PR DESCRIPTION
Variables modified through pointers incorrectly returned cached constant values instead of reloading from memory. This caused wrong results when a variable was initialized with a constant, had its address taken, and was modified through pointer indirection.

Example that was broken:
```c
int b = 10;
int *a = &b;
a[0] = 5;
return b;
```
Previously returned 10 (cached), now correctly returns 5 (reloaded).