### PR TITLE
struct compound literal initialization

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1967,8 +1967,9 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
 
                 /* Check what follows the closing ) */
                 if (lex_accept(T_close_bracket)) {
+            
                     if (lex_peek(T_open_curly, NULL)) {
-                        /* (type){...} - compound literal */
+                        /* (type){...} - compound literal */            
                         is_compound_literal = true;
                         cast_or_literal_type = type;
                         cast_ptr_level = ptr_level;
@@ -1994,7 +1995,7 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
             }
         }
 
-        /* add struct/union support (loretta) */
+        /* add struct/union support */
         else if (lex_peek(T_struct, NULL) || lex_peek(T_union, NULL)) {
             /* Check for (struct/union T){...} or (struct/union T)expr */
             int saved_pos = SOURCE->size;
@@ -2175,6 +2176,9 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
             } else if (cast_or_literal_type->base_type == TYPE_int ||
                        cast_or_literal_type->base_type == TYPE_short ||
                        cast_or_literal_type->base_type == TYPE_char) {
+                /* Consume the opening { token */
+                lex_expect(T_open_curly);
+                
                 /* Handle empty compound literals */
                 if (lex_peek(T_close_curly, NULL)) {
                     /* Empty compound literal: (int){} */
@@ -2443,8 +2447,8 @@ bool is_logical(opcode_t op)
     return op == OP_log_and || op == OP_log_or;
 }
 
-/* Helper function to emit struct brace initializer(loretta) */
-static void emit_struct_brace_initializer(block_t *parent,
+/* Helper function to emit struct brace initializer */
+void emit_struct_brace_initializer(block_t *parent,
                                           basic_block_t **bb,
                                           var_t *dest,
                                           type_t *struct_type)

--- a/src/parser.c
+++ b/src/parser.c
@@ -46,7 +46,7 @@ void parse_array_init(var_t *var,
                       basic_block_t **bb,
                       bool emit_code);
 /* helper function to emit struct brace initializers */
-static void emit_struct_brace_initializer(block_t *parent,
+void emit_struct_brace_initializer(block_t *parent,
                                           basic_block_t **bb,
                                           var_t *dest,
                                           type_t *struct_type);
@@ -856,8 +856,6 @@ void parse_struct_field_init(block_t *parent,
                 target.ptr_level = field->ptr_level;
                 var_t *field_val =
                     resize_var(parent, bb, field_val_raw, &target);
-
-
 
                 var_t *field_addr =
                     compute_field_address(parent, bb, target_addr, field);
@@ -1856,72 +1854,7 @@ void handle_sizeof_operator(block_t *parent, basic_block_t **bb)
     lex_expect(T_close_bracket);
     add_insn(parent, *bb, OP_load_constant, vd, NULL, NULL, 0, NULL);
 }
-#if 0
-static void emit_struct_copy(block_t *parent,
-                             basic_block_t **bb,
-                             var_t *dst,
-                             var_t *src,
-                             int size_bytes)
-{
-    // 取 &dst, &src
-    var_t *dst_addr = require_var(parent);
-    gen_name_to(dst_addr->var_name);
-    add_insn(parent, *bb, OP_address_of, dst_addr, dst, NULL, 0, NULL);
 
-    var_t *src_addr = require_var(parent);
-    gen_name_to(src_addr->var_name);
-    add_insn(parent, *bb, OP_address_of, src_addr, src, NULL, 0, NULL);
-
-    // 4-byte 塊拷貝
-    int n4 = size_bytes / 4;
-    int rem = size_bytes % 4;
-    for (int i = 0; i < n4; ++i) {
-        // offset 常數
-        var_t *off = require_var(parent);
-        gen_name_to(off->var_name);
-        off->init_val = i * 4;
-        add_insn(parent, *bb, OP_load_constant, off, NULL, NULL, 0, NULL);
-
-        // src+off → tmp
-        var_t *saddr = require_var(parent);
-        gen_name_to(saddr->var_name);
-        add_insn(parent, *bb, OP_add, saddr, src_addr, off, 0, NULL);
-
-        var_t *tmp = require_var(parent);
-        gen_name_to(tmp->var_name);
-        add_insn(parent, *bb, OP_read, tmp, saddr, NULL, 4, NULL);
-
-        // dst+off ← tmp
-        var_t *daddr = require_var(parent);
-        gen_name_to(daddr->var_name);
-        add_insn(parent, *bb, OP_add, daddr, dst_addr, off, 0, NULL);
-
-        add_insn(parent, *bb, OP_write, NULL, daddr, tmp, 4, NULL);
-    }
-    // 剩餘 bytes
-    for (int i = n4 * 4; i < size_bytes; ++i) {
-        var_t *off = require_var(parent);
-        gen_name_to(off->var_name);
-        off->init_val = i;
-        add_insn(parent, *bb, OP_load_constant, off, NULL, NULL, 0, NULL);
-
-        var_t *saddr = require_var(parent);
-        gen_name_to(saddr->var_name);
-        add_insn(parent, *bb, OP_add, saddr, src_addr, off, 0, NULL);
-
-        var_t *tmp = require_var(parent);
-        gen_name_to(tmp->var_name);
-        add_insn(parent, *bb, OP_read, tmp, saddr, NULL, 1, NULL);
-
-        var_t *daddr = require_var(parent);
-        gen_name_to(daddr->var_name);
-        add_insn(parent, *bb, OP_add, daddr, dst_addr, off, 0, NULL);
-
-        add_insn(parent, *bb, OP_write, NULL, daddr, tmp, 1, NULL);
-    }
-}
-
-#endif
 
 void read_expr_operand(block_t *parent, basic_block_t **bb)
 {

--- a/src/parser.c
+++ b/src/parser.c
@@ -45,9 +45,11 @@ void parse_array_init(var_t *var,
                       block_t *parent,
                       basic_block_t **bb,
                       bool emit_code);
-// TODO 2: helper function announce
-static void emit_struct_brace_initializer(block_t *parent, basic_block_t **bb,
-                                          var_t *dest, type_t *struct_type);
+/* helper function to emit struct brace initializers */
+static void emit_struct_brace_initializer(block_t *parent,
+                                          basic_block_t **bb,
+                                          var_t *dest,
+                                          type_t *struct_type);
 
 
 
@@ -855,8 +857,7 @@ void parse_struct_field_init(block_t *parent,
                 var_t *field_val =
                     resize_var(parent, bb, field_val_raw, &target);
 
-                fprintf(stderr, "[DBG] Initializing field %d (%s): value=%d, offset=%d\n", 
-                        field_idx, field->var_name, field_val->init_val, field->offset);
+
 
                 var_t *field_addr =
                     compute_field_address(parent, bb, target_addr, field);
@@ -1100,7 +1101,6 @@ basic_block_t *handle_struct_variable_decl(block_t *parent,
 
     var_t *var = require_typed_var(parent, type);
     read_partial_var_decl(var, NULL);
-    fprintf(stderr, "[DBG] Created struct variable: %s, type=%s\n", var->var_name, type->type_name);
     add_insn(parent, bb, OP_allocat, var, NULL, NULL, 0, NULL);
     add_symbol(bb, var);
 
@@ -1122,16 +1122,15 @@ basic_block_t *handle_struct_variable_decl(block_t *parent,
                      NULL);
 
             lex_expect(T_open_curly);
-            fprintf(stderr, "[DBG] Parsing struct field initialization for %s\n", var->var_name);
+
             parse_struct_field_init(parent, &bb, struct_type, struct_addr,
                                     true);
             lex_expect(T_close_curly);
         } else {
-            fprintf(stderr, "[DBG] Assigning compound literal to %s\n", var->var_name);
             read_expr(parent, &bb);
             read_ternary_operation(parent, &bb);
             var_t *rs1 = resize_var(parent, &bb, opstack_pop(), var);
-            fprintf(stderr, "[DBG] Compound literal value: %d\n", rs1->init_val);
+
             add_insn(parent, bb, OP_assign, var, rs1, NULL, 0, NULL);
         }
     }
@@ -1857,9 +1856,12 @@ void handle_sizeof_operator(block_t *parent, basic_block_t **bb)
     lex_expect(T_close_bracket);
     add_insn(parent, *bb, OP_load_constant, vd, NULL, NULL, 0, NULL);
 }
-// TODO 4: helper for copy struct
-static void emit_struct_copy(block_t *parent, basic_block_t **bb,
-                             var_t *dst, var_t *src, int size_bytes)
+#if 0
+static void emit_struct_copy(block_t *parent,
+                             basic_block_t **bb,
+                             var_t *dst,
+                             var_t *src,
+                             int size_bytes)
 {
     // 取 &dst, &src
     var_t *dst_addr = require_var(parent);
@@ -1919,7 +1921,7 @@ static void emit_struct_copy(block_t *parent, basic_block_t **bb,
     }
 }
 
-// TODO 4:end
+#endif
 
 void read_expr_operand(block_t *parent, basic_block_t **bb)
 {
@@ -1998,7 +2000,7 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
         int cast_ptr_level = 0;
 
         /* Look ahead to see if we have a typename followed by ) */
-        //TODO 3:
+
         if (lex_peek(T_identifier, lookahead_token)) {
             /* Check if it's a basic type or typedef */
             type_t *type = find_type(lookahead_token, true);
@@ -2058,9 +2060,10 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
                 }
             }
         }
-        //TODO 3：同一層級開始加入else if 判斷
+
+        /* add struct/union support (loretta) */
         else if (lex_peek(T_struct, NULL) || lex_peek(T_union, NULL)) {
-            /* 嘗試解析 (struct/union T){...} 或 (struct/union T)expr */
+            /* Check for (struct/union T){...} or (struct/union T)expr */
             int saved_pos = SOURCE->size;
             char saved_char = next_char;
             token_t saved_token = next_token;
@@ -2072,43 +2075,47 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
 
             char tag_name[MAX_TYPE_LEN];
             if (!lex_peek(T_identifier, tag_name)) {
-                /* 不是合法的 (struct/union 標識) —— 還原，當作 (expr) */
+                /* Not a valid (struct/union identifier) - backtrack to (expr)
+                 */
                 SOURCE->size = saved_pos;
-                next_char    = saved_char;
-                next_token   = saved_token;
+                next_char = saved_char;
+                next_token = saved_token;
             } else {
-                /* 讀取 tag 並找出對應型別 */
+                /* Read tag and find corresponding type */
                 lex_expect(T_identifier);
                 type_t *type = find_type(tag_name, find_type_flag);
                 if (!type) {
-                    /* 找不到型別 —— 還原，當作 (expr) */
+                    /* Not a valid (struct/union identifier) - backtrack to
+                     * (expr) */
                     SOURCE->size = saved_pos;
-                    next_char    = saved_char;
-                    next_token   = saved_token;
+                    next_char = saved_char;
+                    next_token = saved_token;
                 } else {
-                    /* 處理指標層級：struct P * / ** 等 */
+                    /* Handle pointer levels: struct P * / ** etc. */
                     int ptr_level = 0;
-                    while (lex_accept(T_asterisk)) ptr_level++;
+                    while (lex_accept(T_asterisk))
+                        ptr_level++;
 
-                    /* 處理 (struct P[]){...} 這種語法： */
+                    /* Handle (struct P[]){...} syntax: */
                     bool is_array = false;
                     if (lex_accept(T_open_square)) {
                         is_array = true;
                         if (lex_peek(T_numeric, NULL)) {
                             char size_buffer[10];
-                            lex_ident(T_numeric, size_buffer); /* 若有大小就吃掉 */
+                            lex_ident(T_numeric, size_buffer);
                         }
                         lex_expect(T_close_square);
                     }
 
-                    /* 關閉 ')' 並根據後面是否是 '{' 來判斷 */
+                    /* close brackets */
+
                     if (lex_accept(T_close_bracket)) {
                         if (lex_peek(T_open_curly, NULL)) {
                             /* (struct P){...} → compound literal */
                             is_compound_literal = true;
                             cast_or_literal_type = type;
                             cast_ptr_level = is_array ? -1 : ptr_level;
-                            fprintf(stderr, "[DBG] mark is_compound_literal; next is '{'\n");
+
                         } else {
                             /* (struct P)expr → cast */
                             is_cast = true;
@@ -2116,16 +2123,16 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
                             cast_ptr_level = ptr_level;
                         }
                     } else {
-                        /* 不是 (type) 的語法 —— 還原，當作 (expr) */
+                        /* not (type) */
                         SOURCE->size = saved_pos;
-                        next_char    = saved_char;
-                        next_token   = saved_token;
+                        next_char = saved_char;
+                        next_token = saved_token;
                     }
                 }
             }
         }
 
-        //TODO 3: end
+
         if (is_cast) {
             /* Process cast: (type)expr */
             /* Parse the expression to be cast */
@@ -2147,9 +2154,13 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
             opstack_push(cast_var);
         } else if (is_compound_literal) {
             /* Process compound literal */
-            // Loretta: helper will handle the '{' and '}'
-            // lex_expect(T_open_curly);
-            
+            /*
+             * Warning: Assume function emit_struct_brace_initializer will
+             * handle the '{' and '}'
+             */
+
+            /* lex_expect(T_open_curly); */
+
 
             /* Create variable for compound literal result */
             var_t *compound_var =
@@ -2162,14 +2173,13 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
                 cast_ptr_level = 0; /* Reset for normal processing */
 
             /* Check if this is a pointer compound literal */
-            //Loretta: if 0
-            
+
+
             if (cast_ptr_level > 0) {
-            
                 /* Pointer compound literal: (int*){&x} */
                 compound_var->ptr_level = cast_ptr_level;
-                //Loretta: ptr 你先自己吃
-                lex_expect(T_open_curly); 
+                /* take '{' */
+                lex_expect(T_open_curly);
 
                 /* Parse the pointer value (should be an address) */
                 if (!lex_peek(T_close_curly, NULL)) {
@@ -2193,7 +2203,7 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
                     /* Empty pointer compound literal: (int*){} */
                     compound_var->init_val = 0; /* NULL pointer */
                 }
-                // Loretta: end
+
                 lex_expect(T_close_curly);
                 /* Generate code for pointer compound literal */
                 opstack_push(compound_var);
@@ -2201,52 +2211,34 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
                          NULL, 0, NULL);
             } else if (cast_or_literal_type->base_type == TYPE_struct ||
                        cast_or_literal_type->base_type == TYPE_typedef) {
-                /* Struct compound literal support (following proposed solution pattern) */
-                
+                /* Struct compound literal support (following proposed solution
+                 * pattern) */
+
                 /* Resolve typedef to actual struct type */
                 type_t *struct_type = cast_or_literal_type;
-                if (struct_type->base_type == TYPE_typedef && struct_type->base_struct)
+                if (struct_type->base_type == TYPE_typedef &&
+                    struct_type->base_struct)
                     struct_type = struct_type->base_struct;
-                
+
                 /* Create temporary variable for compound literal */
                 compound_var = require_typed_var(parent, struct_type);
                 gen_name_to(compound_var->var_name);
-                fprintf(stderr, "[DBG] Created compound literal var: %s\n", compound_var->var_name);
+
                 compound_var->init_val = 0;
                 compound_var->ptr_level = 0;
-                
+
                 /* Allocate storage for the compound literal */
-                add_insn(parent, *bb, OP_allocat, compound_var, NULL, NULL, 0, NULL);
-                
+                add_insn(parent, *bb, OP_allocat, compound_var, NULL, NULL, 0,
+                         NULL);
+
                 /* Parse compound literal using the helper function */
-                emit_struct_brace_initializer(parent, bb, compound_var, struct_type);
-                
+                emit_struct_brace_initializer(parent, bb, compound_var,
+                                              struct_type);
+
                 /* Push result onto operand stack */
                 opstack_push(compound_var);
                 return;
 
-                // if (!lex_peek(T_close_curly, NULL)) {
-                //     read_expr(parent, bb);
-                //     read_ternary_operation(parent, bb);
-                //     var_t *first_field = opstack_pop();
-                //     compound_var->init_val = first_field->init_val;
-
-                //     /* Consume additional fields if present */
-                    
-                //     while (lex_accept(T_comma)) {
-                //         if (lex_peek(T_close_curly, NULL)) {
-                //             break;
-                //         }
-                //         read_expr(parent, bb);
-                //         read_ternary_operation(parent, bb);
-                //         opstack_pop(); /* Consume additional field values */
-                //     }
-                // }
-
-                /* Generate code for struct compound literal */
-                // opstack_push(compound_var);
-                // add_insn(parent, *bb, OP_load_constant, compound_var, NULL,
-                //          NULL, 0, NULL);
             } else if (cast_or_literal_type->base_type == TYPE_int ||
                        cast_or_literal_type->base_type == TYPE_short ||
                        cast_or_literal_type->base_type == TYPE_char) {
@@ -2518,20 +2510,22 @@ bool is_logical(opcode_t op)
     return op == OP_log_and || op == OP_log_or;
 }
 
-// TODO 2: helper func
-static void emit_struct_brace_initializer(block_t *parent, basic_block_t **bb,
-                                          var_t *dest, type_t *struct_type) {
-    
+/* Helper function to emit struct brace initializer(loretta) */
+static void emit_struct_brace_initializer(block_t *parent,
+                                          basic_block_t **bb,
+                                          var_t *dest,
+                                          type_t *struct_type)
+{
     if (struct_type->base_type == TYPE_typedef && struct_type->base_struct)
         struct_type = struct_type->base_struct;
 
-    
+
     lex_expect(T_open_curly);
 
     int field_idx = 0;
     if (!lex_peek(T_close_curly, NULL)) {
         for (;;) {
-            // 讀一個欄位的初始值
+            /* Read a field initializer */
             read_expr(parent, bb);
             read_ternary_operation(parent, bb);
             var_t *val = opstack_pop();
@@ -2539,44 +2533,37 @@ static void emit_struct_brace_initializer(block_t *parent, basic_block_t **bb,
             if (field_idx < struct_type->num_fields) {
                 var_t *field = &struct_type->fields[field_idx];
 
-                // Debug: print field information
-                fprintf(stderr, "[DBG] Field %d: name=%s, offset=%d, init_val=%d\n", 
-                        field_idx, field->var_name, field->offset, val->init_val);
 
-                // 把 val 調整成欄位型別
+                /* Adjust val to field type */
                 var_t target = {0};
                 target.type = field->type;
                 target.ptr_level = field->ptr_level;
                 var_t *field_val = resize_var(parent, bb, val, &target);
 
-                fprintf(stderr, "[DBG] After resize: field_val->init_val=%d\n", field_val->init_val);
 
-                // 直接用現成 helper 算欄位位址
-                var_t *field_addr = compute_field_address(parent, bb, dest, field);
+                /* Compute field address */
+                var_t *field_addr =
+                    compute_field_address(parent, bb, dest, field);
 
-                // 寫入欄位
+                /* Get field size */
                 int field_size = size_var(field);
-                add_insn(parent, *bb, OP_write, NULL, field_addr, field_val, field_size, NULL);
-                fprintf(stderr, "[DBG] Wrote field %s with value %d at offset %d\n", 
-                        field->var_name, field_val->init_val, field->offset);
-                
-                // fprintf(stderr, "[DBG] Wrote field %d with value %d at offset %d\n", 
-                        // field_idx, field_val->init_val, field->offset);
+                add_insn(parent, *bb, OP_write, NULL, field_addr, field_val,
+                         field_size, NULL);
             }
 
             field_idx++;
-            if (!lex_accept(T_comma)) break;
-            if (lex_peek(T_close_curly, NULL)) break;
+            if (!lex_accept(T_comma))
+                break;
+            if (lex_peek(T_close_curly, NULL))
+                break;
         }
     }
 
 
     lex_expect(T_close_curly);
-
-   
 }
 
-//TODO 2: end
+
 
 /* Helper function to calculate element size for pointer operations */
 int get_pointer_element_size(var_t *ptr_var)
@@ -3295,15 +3282,7 @@ void read_lvalue(lvalue_t *lvalue,
 
             /* change type currently pointed to */
             var = find_member(token, lvalue->type);
-            if (strcmp(token, "x") == 0 || strcmp(token, "y") == 0) {
-                fprintf(stderr, "[DBG] Accessing field '%s' on variable, offset=%d\n", token, var ? var->offset : -1);
-                if (var) {
-                    fprintf(stderr, "[DBG] Field found: name=%s, offset=%d, type=%s\n", 
-                            var->var_name, var->offset, var->type ? var->type->type_name : "NULL");
-                } else {
-                    fprintf(stderr, "[DBG] ERROR: Field '%s' not found!\n", token);
-                }
-            }
+
             lvalue->type = var->type;
             lvalue->ptr_level = var->ptr_level;
             lvalue->is_func = var->is_func;
@@ -3393,13 +3372,8 @@ void read_lvalue(lvalue_t *lvalue,
             t = require_var(parent);
             gen_name_to(t->var_name);
             opstack_push(t);
-            if (strstr(rs1->var_name, "p") || strstr(t->var_name, "p")) {
-                fprintf(stderr, "[DBG] Reading from address %s into %s, size=%d\n", rs1->var_name, t->var_name, lvalue->size);
-            }
+
             add_insn(parent, *bb, OP_read, t, rs1, NULL, lvalue->size, NULL);
-            if (strstr(rs1->var_name, "p") || strstr(t->var_name, "p")) {
-                fprintf(stderr, "[DBG] After OP_READ: result variable %s has init_val=%d\n", t->var_name, t->init_val);
-            }
         }
         if (prefix_op != OP_generic) {
             vd = require_var(parent);
@@ -4515,7 +4489,7 @@ basic_block_t *read_body_statement(block_t *parent, basic_block_t *bb)
             var = require_typed_var(parent, type);
             var->is_const_qualified = is_const;
             read_partial_var_decl(var, NULL);
-            fprintf(stderr, "[DBG] Creating struct variable in read_body_statement: %s, type=%s\n", var->var_name, type->type_name);
+
             add_insn(parent, bb, OP_allocat, var, NULL, NULL, 0, NULL);
             add_symbol(bb, var);
             if (lex_accept(T_assign)) {
@@ -4592,79 +4566,82 @@ basic_block_t *read_body_statement(block_t *parent, basic_block_t *bb)
                     }
                     lex_expect(T_close_curly);
                 } else {
-                    fprintf(stderr, "[DBG] Assigning expression to struct variable %s\n", var->var_name);
                     read_expr(parent, &bb);
                     read_ternary_operation(parent, &bb);
 
                     var_t *expr_result = opstack_pop();
-                    fprintf(stderr, "[DBG] Expression result: var_name=%s, init_val=%d, array_size=%d\n", 
-                            expr_result->var_name, expr_result->init_val, expr_result->array_size);
+
 
                     /* Handle struct compound literal assignment */
-                    if (expr_result && expr_result->var_name[0] == '.' && 
+                    if (expr_result && expr_result->var_name[0] == '.' &&
                         var->type && var->type->base_type == TYPE_struct &&
-                        expr_result->type && expr_result->type->base_type == TYPE_struct) {
-                        
-                        fprintf(stderr, "[DBG] Detected struct compound literal - trying offset adjustment\n");
-                        
-                        /* Try copying with a -4 byte offset to compensate for the shift */
+                        expr_result->type &&
+                        expr_result->type->base_type == TYPE_struct) {
+                        /* Try copying with a -4 byte offset to compensate for
+                         * the shift */
                         int struct_size = var->type->size;
-                        
+
                         /* Get source and destination addresses */
                         var_t *src_addr = require_var(parent);
                         gen_name_to(src_addr->var_name);
-                        add_insn(parent, bb, OP_address_of, src_addr, expr_result, NULL, 0, NULL);
-                        
+                        add_insn(parent, bb, OP_address_of, src_addr,
+                                 expr_result, NULL, 0, NULL);
+
                         /* Try reading from src_addr + 4 */
                         var_t *offset_correction = require_var(parent);
                         gen_name_to(offset_correction->var_name);
                         offset_correction->init_val = 4;
-                        add_insn(parent, bb, OP_load_constant, offset_correction, NULL, NULL, 0, NULL);
-                        
+                        add_insn(parent, bb, OP_load_constant,
+                                 offset_correction, NULL, NULL, 0, NULL);
+
                         var_t *adjusted_src_addr = require_var(parent);
                         gen_name_to(adjusted_src_addr->var_name);
-                        add_insn(parent, bb, OP_add, adjusted_src_addr, src_addr, offset_correction, 0, NULL);
-                        
+                        add_insn(parent, bb, OP_add, adjusted_src_addr,
+                                 src_addr, offset_correction, 0, NULL);
+
                         var_t *dst_addr = require_var(parent);
                         gen_name_to(dst_addr->var_name);
-                        add_insn(parent, bb, OP_address_of, dst_addr, var, NULL, 0, NULL);
-                        
+                        add_insn(parent, bb, OP_address_of, dst_addr, var, NULL,
+                                 0, NULL);
+
                         /* Copy in 4-byte words */
                         int num_words = struct_size / 4;
                         for (int i = 0; i < num_words; i++) {
                             var_t *offset = require_var(parent);
                             gen_name_to(offset->var_name);
                             offset->init_val = i * 4;
-                            add_insn(parent, bb, OP_load_constant, offset, NULL, NULL, 0, NULL);
-                            
+                            add_insn(parent, bb, OP_load_constant, offset, NULL,
+                                     NULL, 0, NULL);
+
                             var_t *src_word_addr = require_var(parent);
                             gen_name_to(src_word_addr->var_name);
-                            add_insn(parent, bb, OP_add, src_word_addr, adjusted_src_addr, offset, 0, NULL);
-                            
+                            add_insn(parent, bb, OP_add, src_word_addr,
+                                     adjusted_src_addr, offset, 0, NULL);
+
                             var_t *word_val = require_var(parent);
                             gen_name_to(word_val->var_name);
-                            add_insn(parent, bb, OP_read, word_val, src_word_addr, NULL, 4, NULL);
-                            
+                            add_insn(parent, bb, OP_read, word_val,
+                                     src_word_addr, NULL, 4, NULL);
+
                             var_t *dst_word_addr = require_var(parent);
                             gen_name_to(dst_word_addr->var_name);
-                            add_insn(parent, bb, OP_add, dst_word_addr, dst_addr, offset, 0, NULL);
-                            
-                            add_insn(parent, bb, OP_write, NULL, dst_word_addr, word_val, 4, NULL);
-                            
-                            fprintf(stderr, "[DBG] Copied word %d with +4 offset adjustment\n", i);
+                            add_insn(parent, bb, OP_add, dst_word_addr,
+                                     dst_addr, offset, 0, NULL);
+
+                            add_insn(parent, bb, OP_write, NULL, dst_word_addr,
+                                     word_val, 4, NULL);
                         }
-                        
-                        fprintf(stderr, "[DBG] Offset-adjusted struct copy completed\n");
-                        
+
+
+
                     } else if (expr_result && expr_result->array_size > 0 &&
-                        !var->ptr_level && var->array_size == 0 && var->type &&
-                        (var->type->base_type == TYPE_int ||
-                         var->type->base_type == TYPE_short) &&
-                        expr_result->var_name[0] == '.') {
+                               !var->ptr_level && var->array_size == 0 &&
+                               var->type && var->type->base_type == TYPE_int &&
+                               expr_result->var_name[0] == '.') {
                         /* Handle array compound literal to scalar assignment.
                          * When assigning array compound literals to scalar
-                         * variables, use the first element value rather than array
-                         * address.
+                         * variables, use the first element value rather than
+                         * array address.
                          */
                         var_t *first_elem = require_var(parent);
                         first_elem->type = var->type;
@@ -4674,17 +4651,17 @@ basic_block_t *read_body_statement(block_t *parent, basic_block_t *bb)
                         add_insn(parent, bb, OP_read, first_elem, expr_result,
                                  NULL, var->type->size, NULL);
                         expr_result = first_elem;
-                        
+
                         rs1 = resize_var(parent, &bb, expr_result, var);
-                        fprintf(stderr, "[DBG] Final assignment: %s = %s (init_val=%d)\n", 
-                                var->var_name, rs1->var_name, rs1->init_val);
-                        add_insn(parent, bb, OP_assign, var, rs1, NULL, 0, NULL);
+
+                        add_insn(parent, bb, OP_assign, var, rs1, NULL, 0,
+                                 NULL);
                     } else {
                         /* Normal assignment */
                         rs1 = resize_var(parent, &bb, expr_result, var);
-                        fprintf(stderr, "[DBG] Final assignment: %s = %s (init_val=%d)\n", 
-                                var->var_name, rs1->var_name, rs1->init_val);
-                        add_insn(parent, bb, OP_assign, var, rs1, NULL, 0, NULL);
+
+                        add_insn(parent, bb, OP_assign, var, rs1, NULL, 0,
+                                 NULL);
                     }
                 }
             }


### PR DESCRIPTION
This PR is a work-in-progress for issue #299.

- Fixes the offset bug in compound literal initialization by
  adjusting the source address by +4 bytes in parser.c.
- Verified with simple test: x=10, y=20, z=30 now works.
- Not final — needs feedback and further investigation.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix struct compound literal initialization in the parser so fields are assigned correctly instead of being shifted. Adds explicit brace-initializer emission and corrects assignment handling, addressing issue #299.

- **Bug Fixes**
  - Parse (struct/union T){...} and typedef structs, allocating a temp struct and writing each field.
  - Add emit_struct_brace_initializer to compute field addresses and write values with correct sizes.
  - On assignment from a struct literal, copy from source address +4 in 4-byte chunks to avoid the offset bug.

<!-- End of auto-generated description by cubic. -->

