### PR TITLE
Support `goto` statement

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -17,6 +17,7 @@ This document tracks compliance gaps and non-standard behaviors.
 
 ### Control Flow
 - `if`/`else` statements
+- `goto` and label statements
 - `while`, `do-while`, `for` loops
 - `switch`/`case`/`default` statements
 - `break`, `continue`, `return` statements
@@ -96,7 +97,6 @@ This document tracks compliance gaps and non-standard behaviors.
 
 | Feature | Status | Description |
 |---------|--------|-------------|
-| `goto` and labels | Missing | No arbitrary jumps |
 | Designated initializers | Missing | No `.field = value` syntax |
 | Compound literals | Partial | Limited support |
 | Flexible array members | Missing | No `[]` at struct end |
@@ -115,6 +115,7 @@ This document tracks compliance gaps and non-standard behaviors.
 - Escape sequence: `\e` for ESC character
 - `void*` arithmetic (treated as `char*`)
 - `sizeof(void)` returns 0 (should be error)
+- Computed goto
 
 ### Implementation-Specific
 - Array compound literals in scalar context use first element

--- a/src/defs.h
+++ b/src/defs.h
@@ -20,6 +20,7 @@
 #define MAX_LOCALS 1600
 #define MAX_FIELDS 64
 #define MAX_TYPES 256
+#define MAX_LABELS 256
 #define MAX_IR_INSTR 80000
 #define MAX_BB_PRED 128
 #define MAX_BB_DOM_SUCC 64
@@ -179,6 +180,7 @@ typedef enum {
     T_break,
     T_default,
     T_continue,
+    T_goto,
     T_const, /* const qualifier */
     /* C pre-processor directives */
     T_cppd_include,
@@ -270,6 +272,7 @@ typedef enum {
     OP_branch,   /* conditional jump */
     OP_jump,     /* unconditional jump */
     OP_func_ret, /* returned value */
+    OP_label,    /* for goto label */
 
     /* function pointer */
     OP_address_of_func, /* resolve function entry */
@@ -567,6 +570,13 @@ struct ref_block {
  * type, parameters) with SSA-related information (e.g., basic blocks, control
  * flow) to support parsing, analysis, optimization, and code generation.
  */
+
+typedef struct {
+    char label_name[MAX_ID_LEN];
+    basic_block_t *bb;
+    bool used;
+} label_t;
+
 struct func {
     /* Syntatic info */
     var_t return_def;

--- a/src/globals.c
+++ b/src/globals.c
@@ -1481,6 +1481,14 @@ void dump_bb_insn(func_t *func, basic_block_t *bb, bool *at_func_start)
             printf("br %%%s, %s, %s", rs1->var_name, bb->then_->bb_label_name,
                    bb->else_->bb_label_name);
             break;
+        case OP_jump:
+            print_indent(1);
+            printf("jmp %s", bb->next->bb_label_name);
+            break;
+        case OP_label:
+            print_indent(0);
+            printf("%s:", insn->str);
+            break;
         case OP_push:
             print_indent(1);
             printf("push %%%s", rs1->var_name);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -12,7 +12,7 @@
 
 /* Hash table constants */
 #define NUM_DIRECTIVES 11
-#define NUM_KEYWORDS 17
+#define NUM_KEYWORDS 18
 
 /* Token mapping structure for elegant initialization */
 typedef struct {
@@ -85,6 +85,7 @@ void lex_init_keywords()
         {"break", T_break},
         {"default", T_default},
         {"continue", T_continue},
+        {"goto", T_goto},
         {"union", T_union},
         {"const", T_const},
     };
@@ -786,6 +787,8 @@ token_t lex_token_impl(bool aliasing)
                     keyword = T_enum;
             } else if (!memcmp(token_str, "case", 4))
                 keyword = T_case;
+            else if (!memcmp(token_str, "goto", 4))
+                keyword = T_goto;
             break;
 
         case 5: /* 5-letter keywords: while, break, union, const */

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -2559,6 +2559,136 @@ int main() {
 }
 EOF
 
+begin_category "Goto statements" "Testing goto and label statements"
+
+# label undeclaration
+try_compile_error << EOF
+int main()
+{
+    goto label;
+}
+EOF
+
+# label redefinition
+try_compile_error << EOF
+int main()
+{
+    goto label;
+label:
+label:
+}
+EOF
+
+# test label namespace
+try_ 1 << EOF
+int main()
+{
+    goto label;
+label:
+    int label = 1;
+    return label;
+}
+EOF
+
+try_ 0 << EOF
+int main() {
+    int x = 0;
+    goto skip;
+    x = 1;
+skip:
+    return x;  /* Should return 0 */
+}
+EOF
+
+# Forward reference
+try_compile_error << EOF
+int main()
+{
+    goto end;
+    return 1;
+end:
+    return 0;
+}
+EOF
+
+# Simple loop
+try_ 10 << EOF
+int main()
+{
+    int vars0;
+
+    vars0 = 0;
+BB1:
+    if (!(vars0 < 10)) goto BB6;
+    vars0++;
+    goto BB1;
+BB6:
+    return vars0;
+}
+EOF
+
+# Complex loop
+ans="0
+0012345678910123456789201234567893012345678940123456789
+1
+0012345678910123456789201234567893012345678940123456789
+3
+0012345678910123456789201234567893012345678940123456789
+4
+0012345678910123456789201234567893012345678940123456789
+5
+0012345678910123456789201234567893012345678940123456789
+6
+0012345678910123456789201234567893012345678940123456789
+7
+0012345678910123456789201234567893012345678940123456789
+8
+0012345678910123456789201234567893012345678940123456789
+9
+0012345678910123456789201234567893012345678940123456789"
+try_output 0 "$ans" << EOF
+int main()
+{
+    int vars0;
+    int vars1;
+    int vars2;
+    int vars3;
+
+    vars0 = 0;
+BB1:
+    if (!(vars0 < 10)) goto BB47;
+    if (vars0 == 2) goto BB45;
+    printf("%d\n", vars0);
+    vars1 = 0;
+BB10:
+    if (!(vars1 < 10)) goto BB27;
+    if (vars1 == 5) goto BB27;
+    printf("%d", vars1);
+    vars2 = 0;
+BB19:
+    if (!(vars2 < 10)) goto BB25;
+    printf("%d", vars2);
+    vars2++;
+    goto BB19;
+BB25:
+    vars1++;
+    goto BB10;
+BB27:
+    printf("\n");
+    vars3 = 5;
+BB29:
+    if (vars3 == 2) goto BB29;
+    if (vars3 == 3) goto BB45;
+    vars3--;
+    if (vars3 > 0) goto BB29;
+BB45:
+    vars0++;
+    goto BB1;
+BB47:
+    return 0;
+}
+EOF
+
 # Category: Function-like Macros
 begin_category "Function-like Macros" "Testing function-like macros and variadic macros"
 


### PR DESCRIPTION
# Add goto and label statement support
This PR adds full support for C `goto` statements and labels, integrating them with the parser, IR/CFG, and SSA passes. This enables forward/backward jumps, error-handling patterns, and improves C compatibility (#280).

## Changes Made
### Lexer/Parser:
- Add `T_goto`; parse goto identifier; and identifier: labels.
- Function-scoped label table with forward-reference backpatching.
- Report unused label warning.

### IR/CFG:
- Introduce `OP_label`; update text dump and graph dump.
- Lower goto via an if (1) wrapper to keep CFG well-formed (then: jmp label; else: fallthrough).
- Map each label to a basic-block boundary and connect jumps accordingly.

### SSA/Semantics:
- Dominance-based check warns when goto crosses variable initialization (cross-initialization warning).

### Notes:
- Computed goto (GNU extension) is out of scope.

## Testing
- All tests pass on both Stage 0 and Stage 2
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds C goto and label support across the lexer/parser, IR/CFG, and SSA to enable forward/backward jumps and improve C compatibility. Also adds warnings and errors around labels and unsafe jumps.

- **New Features**
  - Lexer/Parser: add T_goto; parse "goto <id>;" and "<id>:" labels; per-function label table with forward-reference backpatching.
  - IR/CFG: add OP_label and OP_jump; map labels to basic-block boundaries; lower goto via an if (1) wrapper to keep CFG well-formed; update text and graph dumps.
  - SSA: dominance-based check warns when a goto crosses a variable’s initialization.
  - Diagnostics: error on undefined labels and duplicate labels; warning on unused labels.
  - Tests: coverage for forward/backward jumps, label namespace, redefinition, and loop patterns.
  - Out of scope: computed goto (GNU extension).

<!-- End of auto-generated description by cubic. -->

