### PR TITLE
Enhance function parsing

### DIFF
--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -5690,6 +5690,123 @@ int main() {
 }
 EOF
 
+begin_category "Function parsing" "Forward declaration and implementation"
+
+# Normal case
+try_output 0 "Hello" << EOF
+void func(char *ptr);
+
+void func(char *ptr)
+{
+    while (*ptr) {
+        printf("%c", *ptr);
+        ptr++;
+    }
+}
+
+int main()
+{
+    func("Hello");
+    return 0;
+}
+EOF
+
+# Incorrect function returning type
+try_compile_error << EOF
+void func(void);
+
+int **func(void)
+{
+    return 3;
+}
+
+int main()
+{
+    func();
+    return 0;
+}
+EOF
+
+# Incorrect number of parameters
+try_compile_error << EOF
+void func(void *a);
+
+void func(void *a, int x)
+{
+    return 3;
+}
+
+int main()
+{
+    func();
+    return 0;
+}
+EOF
+
+# Conflicting parameter types
+try_compile_error << EOF
+void func(void *a, char x);
+
+void func(void *a, int x)
+{
+    return 3;
+}
+
+int main()
+{
+    func();
+    return 0;
+}
+EOF
+
+# Conflicting parameter types (variadic parameters)
+try_compile_error << EOF
+void func(void *a);
+
+void func(void *a, ...)
+{
+    return 3;
+}
+
+int main()
+{
+    func();
+    return 0;
+}
+EOF
+
+# Incorrect function returning type (const)
+try_compile_error << EOF
+void *func(int *a, char x);
+
+const void *func(int *a, char x)
+{
+    return 3;
+}
+
+int main()
+{
+    func();
+    return 0;
+}
+EOF
+
+# Conflicting parameter types (const)
+try_compile_error << EOF
+void func(int *a, char x);
+
+void func(const int *a, char x)
+{
+    return 3;
+}
+
+int main()
+{
+    func();
+    return 0;
+}
+EOF
+
 # Test Results Summary
 
 echo ""


### PR DESCRIPTION
Since the previous parser incorrectly handles a function with a forward declaration before implementation, the code generator may produce wrong instructions due to the incorrect information provided by the frontend.

For example, consider the following example:
```c
int func(char *a);

int func(char *a)
{
    return *a;
}

int main(void)
{
    char a = 10;
    return func(&a);
}
```

After parsing the forward declaration of `func`, it is added to the function list, and its parameter `a` is recorded with the type `char *`. When the function implementation is later parsed, the parser processes the declaration again, but the pointer level of `a` is accumulated, causing the type of `a` to become `char **`.

This can be observed when using shecc to compile and output the IRs:
```
==<START OF INSN DUMP>==
def int @func(char** %a) {
	%.t0 = (%a), 4
	ret %.t0
}
...
```

---
Additionally, if a function with a forward declaration differs from the later declaration, shecc still continues to parse the source instead of reporting an error:
```c
void func(void);

int **func(void)
{
    return 3;
}

int main()
{
    func();
    return 0;
}
```
In the above case, shecc considers `func` to be a function of type `int **(void)`.

---
Therefore, the proposed changes enhance the implementation of the parser to resolve the above issues.
* Reset the pointer level of a parsed variable if it is a function parameter.
* When parsing the function that already exists in the function list, validate that its return type and the data types of all parameters match the previous declaration.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix function parsing for forward-declared functions to keep parameter types correct and to error on conflicting declarations, preventing incorrect IR generation.

- **Bug Fixes**
  - Reset parameter pointer level during parsing to stop pointer accumulation (e.g., char* incorrectly becoming char**).
  - Validate redeclarations against the first declaration: return type and pointer level, parameter count and types, and variadic flag. Abort with clear “before/after” signatures on mismatch.
  - Added tests covering the normal case and conflicts (return type, parameter count/type, variadic).

<!-- End of auto-generated description by cubic. -->

