### PR TITLE
Fix Valgrind leak paths in lexer and preprocessor

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -1412,6 +1412,24 @@ int compact_arenas_selective(int phase_mask)
     return total_saved;
 }
 
+static void free_src_file_map_values(void)
+{
+    if (!SRC_FILE_MAP)
+        return;
+
+    for (int i = 0; i < SRC_FILE_MAP->cap; i++) {
+        if (!SRC_FILE_MAP->table[i].occupied)
+            continue;
+
+        strbuf_t *src = SRC_FILE_MAP->table[i].val;
+        if (!src || src == LIBC_SRC)
+            continue;
+
+        strbuf_free(src);
+        SRC_FILE_MAP->table[i].val = NULL;
+    }
+}
+
 void global_release(void)
 {
     /* Cleanup lexer hashmaps */
@@ -1430,6 +1448,7 @@ void global_release(void)
     arena_free(TOKEN_ARENA);
     arena_free(GENERAL_ARENA); /* free TYPES and PH2_IR_FLATTEN */
     hashmap_free(TOKEN_CACHE);
+    free_src_file_map_values();
     hashmap_free(SRC_FILE_MAP);
     hashmap_free(FUNC_MAP);
     hashmap_free(INCLUSION_MAP);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -966,7 +966,7 @@ token_stream_t *gen_file_token_stream(char *filename)
         error_at("Internal error, expected eof at the end of file",
                  &cur->location);
 
-    tks = malloc(sizeof(token_stream_t));
+    tks = arena_calloc(TOKEN_ARENA, 1, sizeof(token_stream_t));
     tks->head = head.next;
     tks->tail = cur;
     hashmap_put(TOKEN_CACHE, filename, tks);
@@ -1014,7 +1014,7 @@ token_stream_t *gen_libc_token_stream()
         error_at("Internal error, expected eof at the end of file",
                  &cur->location);
 
-    tks = malloc(sizeof(token_stream_t));
+    tks = arena_calloc(TOKEN_ARENA, 1, sizeof(token_stream_t));
     tks->head = head.next;
     tks->tail = cur;
     hashmap_put(TOKEN_CACHE, filename, tks);

--- a/src/preprocessor.c
+++ b/src/preprocessor.c
@@ -1049,25 +1049,25 @@ token_t *preprocess(token_t *tk)
     synth_built_in_loc.line = 1;
     synth_built_in_loc.filename = "<built-in>";
 
-    macro_t *macro = calloc(1, sizeof(macro_t));
+    macro_t *macro = arena_calloc(TOKEN_ARENA, 1, sizeof(macro_t));
     macro->name = "__FILE__";
     macro->handler = file_macro_handler;
     hashmap_put(MACROS, "__FILE__", macro);
 
-    macro = calloc(1, sizeof(macro_t));
+    macro = arena_calloc(TOKEN_ARENA, 1, sizeof(macro_t));
     macro->name = "__LINE__";
     macro->handler = line_macro_handler;
     hashmap_put(MACROS, "__LINE__", macro);
 
     /* architecture defines */
-    macro = calloc(1, sizeof(macro_t));
+    macro = arena_calloc(TOKEN_ARENA, 1, sizeof(macro_t));
     macro->name = ARCH_PREDEFINED;
     macro->replacement = new_token(T_numeric, &synth_built_in_loc, 1);
     macro->replacement->literal = "1";
     hashmap_put(MACROS, ARCH_PREDEFINED, macro);
 
     /* shecc run-time defines */
-    macro = calloc(1, sizeof(macro_t));
+    macro = arena_calloc(TOKEN_ARENA, 1, sizeof(macro_t));
     macro->name = "__SHECC__";
     macro->replacement = new_token(T_numeric, &synth_built_in_loc, 1);
     macro->replacement->literal = "1";


### PR DESCRIPTION
Closes #319.

## Summary

This patch fixes reproducible Valgrind leaks in minimal compiler runs by:

- moving `token_stream_t` allocations in the lexer to `TOKEN_ARENA`
- moving predefined `macro_t` allocations in the preprocessor to `TOKEN_ARENA`
- freeing cached `SRC_FILE_MAP` values before releasing the hashmap

## Verification

Tested with a minimal input:

```c
int main(void)
{
    return 0;
}
```

Valgrind command:

```sh
valgrind \
  --tool=memcheck \
  --leak-check=full \
  --show-leak-kinds=all \
  --track-origins=yes \
  ./out/shecc --no-libc -o /tmp/minimal.elf /tmp/shecc-minimal.c
```

Before:
- `definitely lost: 512 bytes in 6 blocks`
- `indirectly lost: 34 bytes in 1 blocks`

After:
- `in use at exit: 0 bytes in 0 blocks`
- `All heap blocks were freed -- no leaks are possible`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Valgrind-reported memory leaks in the lexer and preprocessor. Moves allocations to the token arena and frees cached source buffers; result: no leaks and no behavior change.

- **Bug Fixes**
  - Allocate token streams in TOKEN_ARENA instead of the heap.
  - Allocate predefined macros in TOKEN_ARENA.
  - Free values in SRC_FILE_MAP before freeing the map.

<sup>Written for commit 0aa2d0991bec9db2144903003e7552e033359f5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

