### PR TITLE
Use the GitHub Releases API to refine the download process for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Download dependencies
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           sudo apt-get update -q -y
           sudo apt-get install -q -y graphviz jq
@@ -23,15 +25,23 @@ jobs:
             if [ "${{ matrix.architecture }}" = "arm" ]; then
               sudo apt-get install -q -y gcc-arm-linux-gnueabihf
             else
-              EXPECTED_SHA256=8eef759d13cb71c332cb4b4faabd522918bb6d694e67a24aa7641453567ff140
-              FILE=/tmp/riscv32-glibc-ubuntu-24.04-gcc.tar.xz
+              # Use the GitHub Releases API to obtain the JSON data of the latest
+              # RISC-V toolchain archive
+              LATEST_RLS_JSON=$(curl --fail --silent --show-error -L -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/riscv-collab/riscv-gnu-toolchain/releases/latest | jq '.assets | .[] | select(.name == "riscv32-glibc-ubuntu-24.04-gcc.tar.xz")')
+
+              # Retrieve SHA256 and URL
+              EXPECTED_SHA256=$(echo $LATEST_RLS_JSON | jq -r .digest | sed 's/sha256://g')
+              URL=$(echo $LATEST_RLS_JSON | jq -r .browser_download_url)
               set -eo pipefail
 
-              sudo wget -qO $FILE https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2026.07.15/riscv32-glibc-ubuntu-24.04-gcc.tar.xz
+              # Download the toolchain archive
+              FILE=/tmp/riscv32-glibc-ubuntu-24.04-gcc.tar.xz
+              sudo wget -qO $FILE $URL
 
-              # Verify sha256
+              # Verify SHA256
               echo "$EXPECTED_SHA256 $FILE" | sha256sum -c -
 
+              # Extract the archive and add "/opt/riscv/bin" to the system path
               sudo tar Jxf $FILE -C /opt
               echo "/opt/riscv/bin" >> "$GITHUB_PATH"
             fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,13 +83,32 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download dependencies
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           sudo dpkg --add-architecture armhf
           sudo apt-get update -q -y
           sudo apt-get install -q -y graphviz jq
           sudo apt-get install -q -y build-essential libc6:armhf
-          sudo wget https://github.com/fastfetch-cli/fastfetch/releases/download/2.58.0/fastfetch-linux-aarch64.deb
-          sudo dpkg -i fastfetch-linux-aarch64.deb
+
+          # Use the GitHub Releases API to obtain the JSON data of the latest
+          # fastfetch package
+          LATEST_RLS_JSON=$(curl --fail --silent --show-error -L -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/fastfetch-cli/fastfetch/releases/latest | jq '.assets | .[] | select(.name == "fastfetch-linux-aarch64.deb")')
+
+          # Retrieve SHA256 and URL
+          EXPECTED_SHA256=$(echo $LATEST_RLS_JSON | jq -r .digest | sed 's/sha256://g')
+          URL=$(echo $LATEST_RLS_JSON | jq -r .browser_download_url)
+          set -eo pipefail
+
+          # Download the fastfetch package
+          FILE=/tmp/fastfetch-linux-aarch64.deb
+          sudo wget -qO $FILE $URL
+
+          # Verify SHA256
+          echo "$EXPECTED_SHA256 $FILE" | sha256sum -c -
+
+          # Install fastfetch
+          sudo dpkg -i /tmp/fastfetch-linux-aarch64.deb
 
       - name: Determine static or dynamic linking mode
         id: determine-mode


### PR DESCRIPTION
The host-x86 and host-arm jobs need to download the RISC-V GNU toolchain and fastfetch, respectively. However, both jobs rely on hard-coded URLs to download the required files, and only the toolchain archive is verified by a fixed SHA256 checksum.

Therefore, the proposed changes introduce the use of the GitHub Releases API to improve the CI flow. The two jobs now use the GitHub Releases API to obtain the release metadata of the target files first, then sequentially perform URL/SHA256 retrieval, download, verification, and installation steps.

As a result, the jobs can always automatically download and install the latest releases without requiring manual updates to the download URLs or checksums.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now uses the GitHub Releases API to resolve, download, and SHA‑256 verify the RISC‑V toolchain (host‑x86) and `fastfetch` (host‑arm), replacing hard‑coded URLs. This keeps jobs on the latest assets and adds checksum verification for `fastfetch`.

- Behavior change: always pulls the latest releases from `riscv-collab/riscv-gnu-toolchain` and `fastfetch-cli/fastfetch`; build results may vary between runs.
- Flow: parse `.browser_download_url` and `.digest` with `jq`, download to `/tmp`, verify with `sha256sum`, then extract to `/opt` and append `/opt/riscv/bin` to `GITHUB_PATH` (toolchain) or install via `dpkg` (`fastfetch`).
- Operational notes: uses `GITHUB_TOKEN` for API calls; steps fail on API or checksum errors; assumes asset names `riscv32-glibc-ubuntu-24.04-gcc.tar.xz` and `fastfetch-linux-aarch64.deb`.

<sup>Written for commit 5940a93c72eb10f8c681e55fca27a6b223a2a3a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/shecc/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

