### PR TITLE
Fix function pointer assignment

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -408,6 +408,7 @@ struct var {
     int loop_depth; /* Nesting depth if variable is in a loop */
     int use_count;  /* Number of times variable is used */
     bool space_is_allocated; /* whether space is allocated for this variable */
+    bool has_backing_storage;
 
     /* This flag is used to indicate to the compiler that the offset of
      * the variable is based on the top of the local stack.

--- a/src/globals.c
+++ b/src/globals.c
@@ -1279,7 +1279,7 @@ void global_init(void)
         arena_init(DEFAULT_ARENA_SIZE); /* For TYPES and PH2_IR_FLATTEN */
 
     /* Use arena allocation for better memory management */
-    TYPES = arena_alloc(GENERAL_ARENA, MAX_TYPES * sizeof(type_t));
+    TYPES = arena_calloc(GENERAL_ARENA, MAX_TYPES, sizeof(type_t));
     PH2_IR_FLATTEN =
         arena_alloc(GENERAL_ARENA, MAX_IR_INSTR * sizeof(ph2_ir_t *));
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -99,6 +99,7 @@ var_t *require_var(block_t *blk)
     var->base = var;
     var->type = TY_int;
     var->space_is_allocated = false;
+    var->has_backing_storage = false;
     var->ofs_based_on_stack_top = false;
     return var;
 }
@@ -110,6 +111,17 @@ var_t *require_typed_var(block_t *blk, type_t *type)
 
     var_t *var = require_var(blk);
     var->type = type;
+    return var;
+}
+
+/* Function-address operands carry a function name, but are not declarations
+ * in the current scope.  Keeping them out of the local lookup list lets
+ * find_var() distinguish a resolved function-pointer variable from a
+ * generated function symbol. */
+var_t *require_func_symbol_var(block_t *blk)
+{
+    var_t *var = require_var(blk);
+    blk->locals.size--;
     return var;
 }
 
@@ -2062,7 +2074,7 @@ void read_expr_operand(block_t *parent, basic_block_t **bb)
                 add_insn(parent, *bb, OP_func_ret, vd, NULL, NULL, 0, NULL);
             } else {
                 /* indirective function pointer assignment */
-                vd = require_var(parent);
+                vd = require_func_symbol_var(parent);
                 vd->is_func = true;
                 strcpy(vd->var_name, intern_string(token));
                 opstack_push(vd);
@@ -3319,12 +3331,17 @@ bool read_body_assignment(char *token,
         } else if (lex_accept(T_andeq)) {
             op = OP_bit_and;
         } else if (lex_peek(T_open_bracket, NULL)) {
-            /* dereference lvalue into function address */
-            rs1 = opstack_pop();
-            vd = require_var(parent);
-            gen_name_to(vd->var_name);
-            opstack_push(vd);
-            add_insn(parent, *bb, OP_read, vd, rs1, NULL, PTR_SIZE, NULL);
+            /* Dereference lvalue first if lvalue is a member access; otherwise,
+             * pass the function pointer value on the stack to
+             * read_indirect_call.
+             */
+            if (lvalue.is_reference) {
+                rs1 = opstack_pop();
+                vd = require_var(parent);
+                gen_name_to(vd->var_name);
+                opstack_push(vd);
+                add_insn(parent, *bb, OP_read, vd, rs1, NULL, PTR_SIZE, NULL);
+            }
 
             read_indirect_call(parent, bb);
             return true;
@@ -3455,6 +3472,34 @@ bool read_body_assignment(char *token,
             if (lvalue.is_func) {
                 rs2 = opstack_pop();
                 rs1 = opstack_pop();
+
+                /* is_func labels both function symbols and function-pointer
+                 * variables. A variable on the RHS must contribute its
+                 * stored pointer value, rather than its identifier being
+                 * lowered as a function address. */
+                if (rs2->is_func && find_var(rs2->var_name, parent) == rs2) {
+                    t = require_ref_var(parent, rs2->type, rs2->ptr_level);
+                    gen_name_to(t->var_name);
+                    add_insn(parent, *bb, OP_address_of, t, rs2, NULL, 0, NULL);
+
+                    vd = require_var(parent);
+                    gen_name_to(vd->var_name);
+                    add_insn(parent, *bb, OP_read, vd, t, NULL, PTR_SIZE, NULL);
+                    rs2 = vd;
+                }
+
+                /* Acquire destination address of lvalue if lvalue is a
+                 * local variable.
+                 */
+                if (!lvalue.is_reference) {
+                    var_t *addr =
+                        require_ref_var(parent, lvalue.type, lvalue.ptr_level);
+                    gen_name_to(addr->var_name);
+                    add_insn(parent, *bb, OP_address_of, addr, rs1, NULL, 0,
+                             NULL);
+                    rs1 = addr;
+                }
+
                 add_insn(parent, *bb, OP_write, NULL, rs1, rs2, PTR_SIZE, NULL);
             } else if (lvalue.is_reference) {
                 rs2 = opstack_pop();
@@ -4565,7 +4610,7 @@ basic_block_t *read_body_statement(block_t *parent, basic_block_t *bb)
     }
 
     /* is a function call? Skip function call check when has_asterisk is true */
-    if (!has_asterisk) {
+    if (!has_asterisk && !find_local_var(token, parent)) {
         func = find_func(token);
         if (func) {
             lex_expect(T_identifier);

--- a/src/reg-alloc.c
+++ b/src/reg-alloc.c
@@ -44,6 +44,46 @@ int align_size(int i)
     return i <= 4 ? 4 : (i + 3) & ~3;
 }
 
+bool aggregate_has_function_pointer_seen(type_t *type,
+                                         type_t **seen,
+                                         int seen_count)
+{
+    if (!type)
+        return false;
+
+    for (int i = 0; i < seen_count; i++)
+        if (seen[i] == type)
+            return false;
+
+    if (seen_count >= MAX_TYPES)
+        return false;
+    seen[seen_count++] = type;
+
+    if (type->base_type == TYPE_typedef && type->base_struct)
+        type = type->base_struct;
+
+    for (int i = 0; i < type->num_fields; i++) {
+        var_t *field = &type->fields[i];
+        if (field->is_func)
+            return true;
+
+        if (!field->ptr_level && field->type && !field->type->ptr_level &&
+            (field->type->base_type == TYPE_struct ||
+             field->type->base_type == TYPE_union ||
+             field->type->base_type == TYPE_typedef) &&
+            aggregate_has_function_pointer_seen(field->type, seen, seen_count))
+            return true;
+    }
+
+    return false;
+}
+
+bool aggregate_has_function_pointer(type_t *type)
+{
+    type_t *seen[MAX_TYPES];
+    return aggregate_has_function_pointer_seen(type, seen, 0);
+}
+
 bool check_live_out(basic_block_t *bb, var_t *var)
 {
     for (int i = 0; i < bb->live_out.size; i++) {
@@ -709,6 +749,11 @@ void reg_alloc(void)
                     else
                         func->stack_size += align_size(sz);
 
+                    if (!insn->rd->is_global &&
+                        aggregate_has_function_pointer(insn->rd->type)) {
+                        insn->rd->has_backing_storage = true;
+                    }
+
                     dest = prepare_dest(bb, insn->rd, -1, -1);
                     ir = bb_add_ph2_ir(bb, OP_address_of);
                     ir->src0 = src0;
@@ -746,6 +791,43 @@ void reg_alloc(void)
                      */
                     insn->rs1->address_taken = true;
                     insn->rs1->is_const = false;
+
+                    /* OP_allocat puts a local aggregate's spill slot before
+                     * its backing storage. &aggregate must name the backing
+                     * storage, not the spill slot.
+                     *
+                     * FIXME: This does not support aggregate parameter for now.
+                     */
+                    bool is_pointer =
+                        insn->rs1->ptr_level ||
+                        (insn->rs1->type && insn->rs1->type->ptr_level);
+                    if (!insn->rs1->is_global && !is_pointer &&
+                        aggregate_has_function_pointer(insn->rs1->type)) {
+                        if (!insn->rs1->has_backing_storage) {
+                            insn->rs1->offset = func->stack_size;
+                            insn->rs1->space_is_allocated = true;
+                            insn->rs1->ofs_based_on_stack_top = false;
+                            func->stack_size += PTR_SIZE;
+                            if (insn->rs1->ptr_level)
+                                sz = PTR_SIZE;
+                            else
+                                sz = insn->rs1->type->size;
+                            if (insn->rs1->array_size)
+                                func->stack_size +=
+                                    align_size(insn->rs1->array_size * sz);
+                            else
+                                func->stack_size += align_size(sz);
+                            insn->rs1->has_backing_storage = true;
+                        }
+
+                        dest = prepare_dest(bb, insn->rd, -1, -1);
+                        ir = bb_add_ph2_ir(bb, OP_address_of);
+                        ir->src0 = insn->rs1->offset + PTR_SIZE;
+                        ir->dest = dest;
+                        ir->ofs_based_on_stack_top =
+                            insn->rs1->ofs_based_on_stack_top;
+                        break;
+                    }
 
                     /* make sure variable is on stack */
                     if (!insn->rs1->space_is_allocated) {
@@ -912,6 +994,9 @@ void reg_alloc(void)
                     is_pushing_args = false;
                     args = 0;
                     handle_abi = false;
+
+                    for (int i = 0; i < REG_CNT; i++)
+                        REGS[i].var = NULL;
                     break;
                 case OP_func_ret:
                     dest = prepare_dest(bb, insn->rd, -1, -1);

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -1643,6 +1643,103 @@ int main() {
 }
 EOF
 
+# Local function pointer, direct struct member, and pointer-to-struct member.
+# The first path must use the pointer value directly; the latter two must load
+# the pointer from the member slot.
+try_ 6 << EOF
+typedef struct {
+    int (*fn)(int);
+} holder_t;
+
+int suc(int x) { return x + 1; }
+
+int main() {
+    int (*local)(int);
+    holder_t h;
+    holder_t *p = &h;
+
+    local = suc;
+    h.fn = suc;
+    p->fn = suc;
+
+    return local(1) + h.fn(1) + p->fn(1);
+}
+EOF
+
+# Assignment between function-pointer variables copies the stored function
+# address; it must not treat the RHS variable name as a function symbol.
+try_ 5 << EOF
+int suc(int x) { return x + 1; }
+
+int main() {
+    int (*first)(int);
+    int (*second)(int);
+
+    first = suc;
+    second = first;
+    return second(4);
+}
+EOF
+
+# A local function pointer shadows a global function.  Copying it must load
+# the local variable's stored target, rather than materializing the global
+# function's address.
+try_ 9 << EOF
+int target(int x) { return x + 3; }
+int replacement(int x) { return x + 8; }
+
+int main() {
+    int (*target)(int);
+    int (*copy)(int);
+
+    target = replacement;
+    copy = target;
+    return copy(1);
+}
+EOF
+
+# An indirect call with two arguments must not leave stale argument-register
+# mappings visible to a later one-argument call.
+try_ 155 << EOF
+typedef struct {
+    int (*add)(int, int);
+} pair_holder_t;
+
+int add(int a, int b) { return a + b; }
+int one(int x) { return x + 100; }
+int get_right() { return 20; }
+
+int main() {
+    pair_holder_t h;
+    int left = 10;
+    int right = get_right();
+    h.add = add;
+    return h.add(left, right) + one(5) + right;
+}
+EOF
+
+
+# Addressing a pointer to a function-pointer aggregate must return the
+# pointer variable's address, not backing storage for its pointee.
+try_ 5 << EOF
+typedef struct {
+    int (*fn)(int);
+} holder_t;
+
+int suc(int x) { return x + 1; }
+
+int call(holder_t *direct) {
+    holder_t **indirect = &direct;
+    return direct == *indirect ? direct->fn(4) : 1;
+}
+
+int main() {
+    holder_t h;
+    h.fn = suc;
+    return call(&h);
+}
+EOF
+
 # struct with multiple pointer declarations in same line
 try_ 42 << EOF
 typedef struct chunk {


### PR DESCRIPTION
This patch fixes function pointer assignment on local variable, direct struct member, and pointer-to-struct member, and also fixes in-register arguments not cleared after invocation of function pointer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes function-pointer assignments so locals and struct members use the correct address and stored pointer value instead of treating variables as function symbols. Indirect calls now clear register mappings afterward, preventing stale arguments from corrupting later calls.

**Bug Fixes**
- Loads function-pointer variables before indirect calls while keeping direct function calls unchanged.
- Handles assignments to local variables, direct struct members, and pointer-to-struct members.
- Copies stored addresses correctly between function-pointer variables.
- Lets a local function pointer shadow a global function instead of resolving to the function symbol.
- Materializes local aggregates containing function-pointer fields in backing storage, including nested aggregates.
- Zero-initializes the type arena so new flags start cleared.
- Adds regression tests for assignments, aggregate addressing, and stale argument-register mappings.

<sup>Written for commit 440d3ae46ab084c902e319457c3345fad5bc124a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/shecc/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

